### PR TITLE
Add cross-platform dev setup for Ubuntu and Mac

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,xml}]
+indent_size = 2
+
+[{mvnw,gradlew}]
+end_of_line = lf
+
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Auto-detect text files and normalize line endings (LF on all platforms)
+* text=auto eol=lf
+
+# Java sources
+*.java text eol=lf
+*.kt text eol=lf
+*.properties text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Scripts
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Build wrappers
+mvnw text eol=lf
+gradlew text eol=lf
+mvnw.cmd text eol=crlf
+gradlew.bat text eol=crlf
+
+# Binary files
+*.jar binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# === Build output ===
+target/
+build/
+out/
+*.class
+*.jar
+*.war
+
+# === Maven ===
+!.mvn/wrapper/maven-wrapper.jar
+!.mvn/wrapper/maven-wrapper.properties
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+
+# === Gradle ===
+.gradle/
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+
+# === IDE - IntelliJ ===
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# === IDE - VS Code ===
+.vscode/
+!.vscode/settings.json
+!.vscode/extensions.json
+
+# === IDE - Eclipse ===
+.classpath
+.project
+.settings/
+bin/
+
+# === OS - macOS ===
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+
+# === OS - Linux ===
+*~
+.nfs*
+.directory
+
+# === Spring Boot ===
+application-local.properties
+application-local.yml
+
+# === Logs ===
+*.log
+logs/
+
+# === Environment ===
+.env
+.env.local
+*.pem
+*.key

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # chat-app
-Chatting app using spring boot
+Chatting app using Spring Boot
+
+## Prerequisites
+- Java 21
+- Maven 3.9+ (or use the included Maven wrapper)
+- Git
+
+## Setup
+
+```bash
+git clone git@github.com:marzuk16/chat-app.git
+cd chat-app
+```
+
+## Build & Run
+
+```bash
+./mvnw spring-boot:run
+```


### PR DESCRIPTION
Closes #4 

## Summary
- Add `.editorconfig` to enforce consistent coding style (UTF-8, LF line endings, 4-space indent) across editors and platforms
- Add `.gitattributes` to normalize line endings (LF for source files, CRLF for Windows scripts) — ensures consistent diffs when working across Ubuntu and macOS
- Add `.gitignore` covering Java/Spring Boot build output, Maven/Gradle files, IDE configs (IntelliJ, VS Code, Eclipse), OS artifacts (macOS `.DS_Store`, Linux temp files), and sensitive files (`.env`, keys)
- Update `README.md` with prerequisites (Java 21, Maven 3.9+) and quick-start instructions

## Test plan
- [ ] Verify `.editorconfig` rules are picked up by IDE (IntelliJ / VS Code)
- [ ] Confirm line endings are normalized on clone (`git ls-files --eol`)
- [ ] Check that ignored files (build output, IDE configs, `.env`) are not tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)