### PR TITLE
feat: add BaseEntity to lib/components (#24)

### DIFF
--- a/lib/components/pom.xml
+++ b/lib/components/pom.xml
@@ -20,6 +20,28 @@
     <name>chat-app :: Lib :: Components</name>
     <description>Shared library — BaseEntity, DTOs, JWT utils, Kafka envelopes, exception handling, constants</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <properties>
         <java.version>21</java.version>
         <lombok.version>1.18.36</lombok.version>

--- a/lib/components/src/main/java/com/marzuk/components/pojos/entity/BaseEntity.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/entity/BaseEntity.java
@@ -1,0 +1,40 @@
+package com.marzuk.components.pojos.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @CreationTimestamp
+    @Column(updatable = false, nullable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @Setter
+    @Column(updatable = false, nullable = false)
+    private String createdBy;
+
+    @Setter
+    @Column(nullable = false)
+    private String updatedBy;
+}

--- a/lib/components/src/test/java/com/marzuk/components/TestConfig.java
+++ b/lib/components/src/test/java/com/marzuk/components/TestConfig.java
@@ -1,0 +1,7 @@
+package com.marzuk.components;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+class TestConfig {
+}

--- a/lib/components/src/test/java/com/marzuk/components/pojos/entity/BaseEntityTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/entity/BaseEntityTest.java
@@ -1,0 +1,59 @@
+package com.marzuk.components.pojos.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@EntityScan(basePackageClasses = BaseEntityTest.class)
+class BaseEntityTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void idAndTimestampsArePopulatedOnPersist() {
+        SampleEntity sampleEntity = new SampleEntity();
+        sampleEntity.setTitle("sample");
+        sampleEntity.setCreatedBy("alice");
+        sampleEntity.setUpdatedBy("alice");
+
+        SampleEntity persistedEntity = entityManager.persistFlushFind(sampleEntity);
+
+        assertThat(persistedEntity.getId()).isNotNull();
+        assertThat(persistedEntity.getCreatedAt()).isNotNull();
+        assertThat(persistedEntity.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void createdByIsImmutableAfterPersist() {
+        SampleEntity sampleEntity = new SampleEntity();
+        sampleEntity.setTitle("sample");
+        sampleEntity.setCreatedBy("alice");
+        sampleEntity.setUpdatedBy("alice");
+
+        SampleEntity persistedEntity = entityManager.persistFlushFind(sampleEntity);
+        assertThat(persistedEntity.getCreatedBy()).isEqualTo("alice");
+
+        persistedEntity.setUpdatedBy("bob");
+        SampleEntity updatedEntity = entityManager.persistFlushFind(persistedEntity);
+
+        assertThat(updatedEntity.getCreatedBy()).isEqualTo("alice");
+        assertThat(updatedEntity.getUpdatedBy()).isEqualTo("bob");
+    }
+
+    @Entity
+    @Table(name = "sample_entity")
+    static class SampleEntity extends BaseEntity {
+        private String title;
+
+        public String getTitle() { return title; }
+        public void setTitle(String title) { this.title = title; }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BaseEntity` abstract class to `lib/components` as the shared JPA base for all service entities
- Uses Hibernate `@CreationTimestamp`/`@UpdateTimestamp` for automatic timestamp management
- `createdBy` and `updatedBy` are non-null columns set manually from the service layer; `createdBy` is immutable after insert

## Changes
- `lib/components/pom.xml` — added `spring-boot-starter-data-jpa` and test dependencies (H2, spring-boot-starter-test)
- `BaseEntity.java` — `@MappedSuperclass` with UUID id, `createdAt`, `updatedAt`, `createdBy` (updatable=false), `updatedBy`
- `TestConfig.java` — minimal `@SpringBootApplication` bootstrap for `@DataJpaTest` in a lib module
- `BaseEntityTest.java` — two `@DataJpaTest` tests verifying timestamp population and `createdBy` immutability

## Test plan
- [x] Unit/integration tests pass (`mvn test -pl lib/components`)
- [ ] Downstream services (auth, user, chat, etc.) extend `BaseEntity` and verify compile

Closes #24