### PR TITLE
feat: add Response and PageResponse wrappers to lib/components (#25)

### DIFF
--- a/.claude/commands/pick_task.md
+++ b/.claude/commands/pick_task.md
@@ -42,26 +42,21 @@ git checkout -b feature/issue-$ARGUMENTS-<short-slug> origin/staging
 - Integration tests using Testcontainers for DB / Kafka / MinIO interactions.
 
 ### PR
+
+Read `.github/PULL_REQUEST_TEMPLATE.md`, fill in the placeholders based on the implementation, and set `Closes: #$ARGUMENTS`. Pass the populated content as the `--body` to `gh pr create`.
+
+Apply `--label` flags for:
+- **Service**: match the service the issue touches to one of: `common`, `config`, `gateway`, `auth`, `user`, `chat`, `media`, `notification`, `presence`, `admin`, `infrastructure`
+- **Type**: match the issue type to one of: `Feature`, `Task`, `🐞 Bug`
+- **Status**: always add `👋  Waiting For Review`
+
 ```bash
 gh pr create \
   --base staging \
   --title "<concise title> (#$ARGUMENTS)" \
-  --body "$(cat <<'EOF'
-## Summary
-- <bullet 1>
-- <bullet 2>
-
-## Changes
-- <layer-by-layer summary>
-
-## Test plan
-- [ ] Unit tests pass
-- [ ] Integration tests pass
-- [ ] Manual smoke-test steps
-
-Closes #$ARGUMENTS
-EOF
-)"
+  --label "<service>" \
+  --label "<Feature|Task|🐞 Bug>" \
+  --label "👋  Waiting For Review"
 ```
 
 Push the branch and return the PR URL to the user.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
 ## Related Issue
-Closes #
+Closes:
+- #
 
 ## What I Did
--
+- <bullet 1>                                                                                                                                        
+- <bullet 2>
 
 ## How to Test
 -

--- a/lib/components/src/main/java/com/marzuk/components/pojos/response/PageResponse.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/response/PageResponse.java
@@ -1,0 +1,30 @@
+package com.marzuk.components.pojos.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PageResponse<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    public static <T> PageResponse<T> from(Page<T> pageData) {
+        return PageResponse.<T>builder()
+                .content(pageData.getContent())
+                .page(pageData.getNumber())
+                .size(pageData.getSize())
+                .totalElements(pageData.getTotalElements())
+                .totalPages(pageData.getTotalPages())
+                .last(pageData.isLast())
+                .build();
+    }
+}

--- a/lib/components/src/main/java/com/marzuk/components/pojos/response/Response.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/response/Response.java
@@ -1,0 +1,43 @@
+package com.marzuk.components.pojos.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Builder
+public class Response<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+    private Instant timestamp;
+    private List<String> errors;
+
+    public static <T> Response<T> success(T data) {
+        return Response.<T>builder()
+                .success(true)
+                .data(data)
+                .timestamp(Instant.now())
+                .build();
+    }
+
+    public static <T> Response<T> error(String message) {
+        return Response.<T>builder()
+                .success(false)
+                .message(message)
+                .timestamp(Instant.now())
+                .build();
+    }
+
+    public static <T> Response<T> error(String message, List<String> errors) {
+        return Response.<T>builder()
+                .success(false)
+                .message(message)
+                .errors(errors)
+                .timestamp(Instant.now())
+                .build();
+    }
+}

--- a/lib/components/src/test/java/com/marzuk/components/pojos/response/PageResponseTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/response/PageResponseTest.java
@@ -1,0 +1,40 @@
+package com.marzuk.components.pojos.response;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageResponseTest {
+
+    @Test
+    void fromPageMapsAllPaginationFieldsCorrectly() {
+        List<String> items = List.of("alpha", "beta", "gamma");
+        PageRequest pageRequest = PageRequest.of(1, 3);
+        Page<String> springPage = new PageImpl<>(items, pageRequest, 9);
+
+        PageResponse<String> pageResponse = PageResponse.from(springPage);
+
+        assertThat(pageResponse.getContent()).containsExactlyElementsOf(items);
+        assertThat(pageResponse.getPage()).isEqualTo(1);
+        assertThat(pageResponse.getSize()).isEqualTo(3);
+        assertThat(pageResponse.getTotalElements()).isEqualTo(9);
+        assertThat(pageResponse.getTotalPages()).isEqualTo(3);
+        assertThat(pageResponse.isLast()).isFalse();
+    }
+
+    @Test
+    void fromPageSetsLastTrueOnFinalPage() {
+        List<String> items = List.of("alpha");
+        PageRequest pageRequest = PageRequest.of(2, 3);
+        Page<String> springPage = new PageImpl<>(items, pageRequest, 7);
+
+        PageResponse<String> pageResponse = PageResponse.from(springPage);
+
+        assertThat(pageResponse.isLast()).isTrue();
+    }
+}

--- a/lib/components/src/test/java/com/marzuk/components/pojos/response/ResponseTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/response/ResponseTest.java
@@ -1,0 +1,43 @@
+package com.marzuk.components.pojos.response;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseTest {
+
+    @Test
+    void successFactorySetsTrueWithDataAndTimestamp() {
+        Response<String> response = Response.success("payload");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isEqualTo("payload");
+        assertThat(response.getTimestamp()).isNotNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrors()).isNull();
+    }
+
+    @Test
+    void errorFactorySetsFalseWithMessageAndTimestamp() {
+        Response<Void> response = Response.error("something went wrong");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("something went wrong");
+        assertThat(response.getTimestamp()).isNotNull();
+        assertThat(response.getData()).isNull();
+        assertThat(response.getErrors()).isNull();
+    }
+
+    @Test
+    void errorWithErrorsFactoryPopulatesErrorsList() {
+        List<String> validationErrors = List.of("name is required", "email is invalid");
+        Response<Void> response = Response.error("validation failed", validationErrors);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("validation failed");
+        assertThat(response.getErrors()).containsExactlyElementsOf(validationErrors);
+        assertThat(response.getTimestamp()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes:
- #25

## What I Did
- Added `Response<T>` with `success`, `message`, `data`, `timestamp`, `errors` fields and three static factories: `success(data)`, `error(message)`, `error(message, errors)`
- Added `PageResponse<T>` with pagination fields and a `from(Page<T>)` static factory that maps Spring Data `Page` directly

## How to Test
- Run `mvn test -pl lib/components`
- `ResponseTest` covers all three factory methods
- `PageResponseTest` verifies field mapping and last-page detection

## Checklist
- [x] Code works
- [x] Tested locally
- [x] No breaking changes