### PR TITLE
Add JWT utility class to common-lib (#27)

### DIFF
--- a/docs/plan/task_plan_27.md
+++ b/docs/plan/task_plan_27.md
@@ -1,0 +1,82 @@
+# Task Plan — Issue #27: Add JWT Utility Class to `common-lib`
+
+## What
+
+A `JwtUtil` class in `lib/components` that **parses and validates** JWTs (no token issuance). Provides: `extractAllClaims`, `extractUserId`, `extractRole`, `extractEmail`, `isTokenExpired`, and `validateToken`. The signing key is externalized via Spring config.
+
+**Labels:** common, Feature, priority: critical
+**Depends on:** #24 (already merged — `UnauthorizedException` is available)
+**Blocks:** #28
+
+---
+
+## Services / Modules Touched
+
+- `lib/components` only — shared library consumed by `auth`, `api-gateway`, and future services.
+
+---
+
+## Components
+
+| Component | Package | Responsibility |
+|---|---|---|
+| `JwtProperties` | `com.marzuk.components.security` | `@ConfigurationProperties(prefix = "jwt")` holding the signing key |
+| `JwtUtil` | `com.marzuk.components.security` | Stateless utility — parse claims, validate tokens |
+
+---
+
+## Design
+
+### `JwtProperties`
+- `@ConfigurationProperties(prefix = "jwt")` with a `secretKey` field.
+- Each consuming service provides `jwt.secret-key` in its own config.
+
+### `JwtUtil`
+- `@Component` with constructor injection of `JwtProperties`.
+- Methods:
+  - `extractAllClaims(String token)` → `Claims` — parses and returns all claims; throws `UnauthorizedException` on failure.
+  - `extractUserId(String token)` → `UUID` — reads the `sub` claim.
+  - `extractRole(String token)` → `String` — reads a `role` claim.
+  - `extractEmail(String token)` → `String` — reads an `email` claim.
+  - `isTokenExpired(String token)` → `boolean` — checks `exp` claim against current time.
+  - `validateToken(String token)` → `Claims` — calls `extractAllClaims` + checks expiry; throws `UnauthorizedException` for malformed/expired tokens.
+
+### JJWT dependency
+- Add `io.jsonwebtoken:jjwt-api`, `jjwt-impl`, and `jjwt-jackson` (0.12.x) to `lib/components/pom.xml`.
+
+---
+
+## SOLID / KISS Notes
+
+- **SRP**: `JwtUtil` only parses/validates; `JwtProperties` only holds config.
+- **OCP**: Consumers can read additional claims via `extractAllClaims` without modifying `JwtUtil`.
+- **KISS**: No abstract factory, no strategy pattern — direct JJWT calls only.
+
+---
+
+## Files to Create / Modify
+
+| Action | File |
+|---|---|
+| Modify | `lib/components/pom.xml` — add JJWT dependencies |
+| Create | `lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java` |
+| Create | `lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java` |
+| Create | `lib/components/src/test/java/com/marzuk/components/security/JwtUtilTest.java` |
+
+---
+
+## Tests
+
+Unit tests only — no Spring context, no Testcontainers. Construct `JwtUtil` directly with a test `JwtProperties`. Generate real JWTs via JJWT builder using a test secret key.
+
+| Test | What it verifies |
+|---|---|
+| `extractUserId_returnsCorrectUuid` | Parses `sub` from a valid token |
+| `extractRole_returnsCorrectRole` | Parses `role` claim |
+| `extractEmail_returnsCorrectEmail` | Parses `email` claim |
+| `isTokenExpired_returnsFalseForValidToken` | Non-expired token → `false` |
+| `isTokenExpired_returnsTrueForExpiredToken` | Expired token → `true` |
+| `validateToken_returnsClaimsForValidToken` | Valid token passes validation |
+| `validateToken_throwsForExpiredToken` | Expired token → `UnauthorizedException` |
+| `validateToken_throwsForMalformedToken` | Garbage string → `UnauthorizedException` |
+| `validateToken_throwsForWrongSigningKey` | Token signed with different key → `UnauthorizedException` |

--- a/lib/components/pom.xml
+++ b/lib/components/pom.xml
@@ -36,6 +36,23 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
@@ -51,6 +68,7 @@
         <java.version>21</java.version>
         <lombok.version>1.18.36</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
+        <jjwt.version>0.12.6</jjwt.version>
     </properties>
 
     <build>

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
@@ -1,17 +1,11 @@
 package com.marzuk.components.security;
 
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Data
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
     private String secretKey;
-
-    public String getSecretKey() {
-        return secretKey;
-    }
-
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
-    }
 }

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
@@ -1,9 +1,11 @@
 package com.marzuk.components.security;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Data
+@Getter
+@Setter
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.marzuk.components.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String secretKey;
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+}

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
@@ -1,0 +1,63 @@
+package com.marzuk.components.security;
+
+import com.marzuk.components.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey signingKey;
+
+    public JwtUtil(JwtProperties jwtProperties) {
+        this.signingKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Claims extractAllClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(signingKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException exception) {
+            // Return embedded claims so callers can inspect expiry (e.g. isTokenExpired)
+            return exception.getClaims();
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new UnauthorizedException("Invalid or malformed JWT token");
+        }
+    }
+
+    public UUID extractUserId(String token) {
+        return UUID.fromString(extractAllClaims(token).getSubject());
+    }
+
+    public String extractRole(String token) {
+        return extractAllClaims(token).get("role", String.class);
+    }
+
+    public String extractEmail(String token) {
+        return extractAllClaims(token).get("email", String.class);
+    }
+
+    public boolean isTokenExpired(String token) {
+        return extractAllClaims(token).getExpiration().before(new Date());
+    }
+
+    public Claims validateToken(String token) {
+        Claims claims = extractAllClaims(token);
+        if (claims.getExpiration().before(new Date())) {
+            throw new UnauthorizedException("JWT token has expired");
+        }
+        return claims;
+    }
+}

--- a/lib/components/src/test/java/com/marzuk/components/security/JwtUtilTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/security/JwtUtilTest.java
@@ -1,0 +1,123 @@
+package com.marzuk.components.security;
+
+import com.marzuk.components.exception.UnauthorizedException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtUtilTest {
+
+    private static final String SECRET_KEY = "test-secret-key-that-is-long-enough-for-hmac-sha256";
+    private static final String DIFFERENT_SECRET_KEY = "different-secret-key-that-is-long-enough-for-hmac";
+
+    private JwtUtil jwtUtil;
+    private SecretKey signingKey;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecretKey(SECRET_KEY);
+        jwtUtil = new JwtUtil(jwtProperties);
+        signingKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String buildValidToken(UUID userId, String role, String email) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("role", role)
+                .claim("email", email)
+                .expiration(new Date(System.currentTimeMillis() + 60_000))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    private String buildExpiredToken(UUID userId) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .expiration(new Date(System.currentTimeMillis() - 1_000))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    @Test
+    void extractUserId_returnsCorrectUuid() {
+        UUID userId = UUID.randomUUID();
+        String token = buildValidToken(userId, "USER", "user@example.com");
+
+        assertThat(jwtUtil.extractUserId(token)).isEqualTo(userId);
+    }
+
+    @Test
+    void extractRole_returnsCorrectRole() {
+        String token = buildValidToken(UUID.randomUUID(), "ADMIN", "admin@example.com");
+
+        assertThat(jwtUtil.extractRole(token)).isEqualTo("ADMIN");
+    }
+
+    @Test
+    void extractEmail_returnsCorrectEmail() {
+        String token = buildValidToken(UUID.randomUUID(), "USER", "user@example.com");
+
+        assertThat(jwtUtil.extractEmail(token)).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void isTokenExpired_returnsFalseForValidToken() {
+        String token = buildValidToken(UUID.randomUUID(), "USER", "user@example.com");
+
+        assertThat(jwtUtil.isTokenExpired(token)).isFalse();
+    }
+
+    @Test
+    void isTokenExpired_returnsTrueForExpiredToken() {
+        String token = buildExpiredToken(UUID.randomUUID());
+
+        assertThat(jwtUtil.isTokenExpired(token)).isTrue();
+    }
+
+    @Test
+    void validateToken_returnsClaimsForValidToken() {
+        UUID userId = UUID.randomUUID();
+        String token = buildValidToken(userId, "USER", "user@example.com");
+
+        var claims = jwtUtil.validateToken(token);
+
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+    }
+
+    @Test
+    void validateToken_throwsForExpiredToken() {
+        String token = buildExpiredToken(UUID.randomUUID());
+
+        assertThatThrownBy(() -> jwtUtil.validateToken(token))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void validateToken_throwsForMalformedToken() {
+        assertThatThrownBy(() -> jwtUtil.validateToken("this.is.garbage"))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void validateToken_throwsForWrongSigningKey() {
+        SecretKey differentKey = Keys.hmacShaKeyFor(DIFFERENT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .subject(UUID.randomUUID().toString())
+                .expiration(new Date(System.currentTimeMillis() + 60_000))
+                .signWith(differentKey)
+                .compact();
+
+        assertThatThrownBy(() -> jwtUtil.validateToken(token))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes:
- #27

## What I Did
- Added `JwtProperties` (`@ConfigurationProperties(prefix = "jwt")`) to externalize the signing key
- Added `JwtUtil` to `lib/components` with parsing/validation methods: `extractAllClaims`, `extractUserId`, `extractRole`, `extractEmail`, `isTokenExpired`, `validateToken`
- Added JJWT 0.12.6 dependencies (`jjwt-api`, `jjwt-impl`, `jjwt-jackson`) to `lib/components/pom.xml`
- Used precise Lombok annotations (`@Getter`, `@Setter`) on `JwtProperties`

## How to Test
- Run `mvn test -pl lib/components` — 9 JWT unit tests covering valid, expired, malformed, and wrong-key tokens
- All 26 module tests pass

## Checklist
- [x] Code works
- [x] Tested locally
- [x] No breaking changes

## Plan
See [docs/plan/task_plan_27.md](docs/plan/task_plan_27.md)