### PR TITLE
Add shared constants to common-lib (#30)

### DIFF
--- a/docs/plan/task_plan_30.md
+++ b/docs/plan/task_plan_30.md
@@ -1,0 +1,44 @@
+# Task Plan — Issue #30: Add shared constants to common-lib
+
+## What
+Add three utility constant classes to `lib/components` so all services reference a single source of truth for Kafka topic names, HTTP header keys, and Spring Security role strings.
+
+## Services / Modules Touched
+- `lib/components` only
+
+## New Package
+`com.marzuk.components.constants`
+
+## Classes
+
+### `KafkaTopics.java`
+Static `String` constants for all Kafka topic names:
+- `USER_REGISTERED`
+- `USER_LOCKED`
+- `USER_PRESENCE_CHANGED`
+- `MESSAGE_SENT`
+- `CHAT_USER_ACTIVITY`
+- `ADMIN_BROADCAST`
+
+### `AppHeaders.java`
+Static `String` constants for HTTP header keys:
+- `USER_ID` → `"X-User-Id"`
+- `USER_ROLE` → `"X-User-Role"`
+- `REQUEST_ID` → `"X-Request-Id"`
+
+### `Roles.java`
+Static `String` constants matching Spring Security format:
+- `USER` → `"ROLE_USER"`
+- `ADMIN` → `"ROLE_ADMIN"`
+
+## Design Notes
+- All classes use `@NoArgsConstructor(access = AccessLevel.NONE)` (Lombok) to prevent instantiation — no manual private constructors.
+- Plain `static final String` fields — no enums, no config injection. Compile-time constants.
+- **SOLID**: SRP — each class owns one concern.
+- **KISS**: simplest correct shape; no unnecessary abstraction.
+
+## Tests
+None required — static constant declarations contain no logic to test.
+
+## Size
+S (3 new files, 1 new package, 1 module)

--- a/lib/components/src/main/java/com/marzuk/components/constants/AppHeaders.java
+++ b/lib/components/src/main/java/com/marzuk/components/constants/AppHeaders.java
@@ -1,0 +1,12 @@
+package com.marzuk.components.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public class AppHeaders {
+
+    public static final String USER_ID = "X-User-Id";
+    public static final String USER_ROLE = "X-User-Role";
+    public static final String REQUEST_ID = "X-Request-Id";
+}

--- a/lib/components/src/main/java/com/marzuk/components/constants/KafkaTopics.java
+++ b/lib/components/src/main/java/com/marzuk/components/constants/KafkaTopics.java
@@ -1,0 +1,15 @@
+package com.marzuk.components.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public class KafkaTopics {
+
+    public static final String USER_REGISTERED = "user.registered";
+    public static final String USER_LOCKED = "user.locked";
+    public static final String USER_PRESENCE_CHANGED = "user.presence-changed";
+    public static final String MESSAGE_SENT = "message.sent";
+    public static final String CHAT_USER_ACTIVITY = "chat.user-activity";
+    public static final String ADMIN_BROADCAST = "admin.broadcast";
+}

--- a/lib/components/src/main/java/com/marzuk/components/constants/Roles.java
+++ b/lib/components/src/main/java/com/marzuk/components/constants/Roles.java
@@ -1,0 +1,11 @@
+package com.marzuk.components.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public class Roles {
+
+    public static final String USER = "ROLE_USER";
+    public static final String ADMIN = "ROLE_ADMIN";
+}


### PR DESCRIPTION
## Related Issue
Closes: #30

## What I Did
- Added `KafkaTopics` constants class with all Kafka topic name strings
- Added `AppHeaders` constants class with `X-User-Id`, `X-User-Role`, `X-Request-Id` header keys
- Added `Roles` constants class with Spring Security-format role strings (`ROLE_USER`, `ROLE_ADMIN`)

All classes live under `com.marzuk.components.constants` in `lib/components`.

Implementation plan: [docs/plan/task_plan_30.md](docs/plan/task_plan_30.md)

## How to Test
- Build `lib/components`: `mvn clean package -pl lib/components`

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes