### PR TITLE
feat: replace HMAC JWT secret with RSA asymmetric key pair (#172)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 JWT_PRIVATE_KEY=replace-with-base64-encoded-rsa-private-key
 JWT_PUBLIC_KEY=replace-with-base64-encoded-rsa-public-key
+
+ACTIVE_PROFILES=compose,dev

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-JWT_SECRET_KEY=replace-with-a-secure-random-256-bit-secret
+JWT_PRIVATE_KEY=replace-with-base64-encoded-rsa-private-key
+JWT_PUBLIC_KEY=replace-with-base64-encoded-rsa-public-key

--- a/docs/plan/task_plan_172.md
+++ b/docs/plan/task_plan_172.md
@@ -1,0 +1,69 @@
+# Task Plan — Issue #172: Replace HMAC JWT secret with RSA asymmetric key pair
+
+## What
+Replace the shared HMAC symmetric secret (`JWT_SECRET_KEY`) with an RSA 4096-bit asymmetric key pair.
+The auth service holds the private key (for signing tokens), while all other services only receive
+the public key (for verification). This follows the principle of least privilege — a compromised
+downstream service cannot forge tokens.
+
+## Services Touched
+- `lib/components` — shared security classes
+- `packages/auth` — config only (will use both keys)
+- `packages/api-gateway` — config only (public key only)
+- `infrastructure/bash/init_scripts/initialize.sh` — key generation
+
+## Changes by File
+
+### 1. `infrastructure/bash/init_scripts/initialize.sh`
+- Generate RSA 4096 private key with `openssl genrsa`
+- Extract the public key with `openssl rsa -pubout`
+- Base64-encode both keys (single-line) for safe storage in `.env`
+- Write `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` to `.env`
+
+### 2. `.env.example`
+- Replace `JWT_SECRET_KEY=...` with `JWT_PRIVATE_KEY=...` and `JWT_PUBLIC_KEY=...`
+
+### 3. `lib/components` — `JwtProperties.java`
+- Remove `secretKey` field
+- Add `publicKey` (required — all services need it for verification)
+- Add `privateKey` (optional — only auth needs it for signing)
+
+### 4. `lib/components` — `JwtUtil.java`
+- Constructor decodes Base64 `publicKey` -> `RSAPublicKey`
+- Optionally decodes Base64 `privateKey` -> `RSAPrivateKey` (if provided)
+- `verifyWith(publicKey)` replaces `verifyWith(signingKey)` for parsing
+- Expose `getSigningKey()` so the auth service can sign tokens later (returns `RSAPrivateKey`)
+
+### 5. `packages/auth/src/main/resources/application.yml`
+- Replace `jwt.secretKey` with `jwt.privateKey: ${JWT_PRIVATE_KEY}` and `jwt.publicKey: ${JWT_PUBLIC_KEY}`
+
+### 6. `packages/api-gateway/src/main/resources/application.yml`
+- Replace `jwt.secretKey` with `jwt.publicKey: ${JWT_PUBLIC_KEY}` only
+
+### 7. `lib/components` — `JwtUtilTest.java`
+- Generate a test RSA key pair programmatically (`KeyPairGenerator.getInstance("RSA")`)
+- Update `buildValidToken` / `buildExpiredToken` to sign with the test private key
+- Update `JwtUtil` instantiation to use Base64-encoded test keys
+- Update `validateToken_throwsForWrongSigningKey` to use a different RSA key pair
+
+## No Changes Needed
+- `SecurityConfig.java` — injects `JwtUtil` as before
+- `JwtAuthenticationFilter.java` — calls `jwtUtil.validateToken()` as before
+- `SecurityProperties.java` — unchanged
+
+## KISS Check
+- No new classes introduced; only modifying existing ones
+- RSA key loading uses standard JDK (`KeyFactory` + `X509EncodedKeySpec` / `PKCS8EncodedKeySpec`) — no new dependencies
+- Optional `privateKey` avoids splitting `JwtUtil` into two classes prematurely; a simple null check suffices
+
+## Tests
+
+### Unit tests (updated `JwtUtilTest.java`)
+- All existing tests re-verified with RSA keys
+- `extractUserId`, `extractRole`, `extractEmail` — valid token signed with test private key
+- `isTokenExpired` — valid + expired tokens
+- `validateToken` — valid, expired, malformed, wrong-key scenarios
+- New: verify JwtUtil constructs successfully without a private key (verify-only mode)
+
+### No new integration tests needed
+This is a pure in-memory crypto change with no external infrastructure.

--- a/infrastructure/bash/init_scripts/initialize.sh
+++ b/infrastructure/bash/init_scripts/initialize.sh
@@ -23,6 +23,8 @@ echo ".env file generation has started ..."
 cat > .env << ENDOFFILE
 JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY}
 JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY}
+
+ACTIVE_PROFILES=compose,dev
 ENDOFFILE
 
 echo ".env file generation done."

--- a/infrastructure/bash/init_scripts/initialize.sh
+++ b/infrastructure/bash/init_scripts/initialize.sh
@@ -4,15 +4,25 @@ set -e
 ### Log
 echo "Project initialisation has started ..."
 
-### Generate JWT secret key
-echo "Generating JWT secret key ..."
-JWT_SECRET_KEY=$(openssl rand -hex 32)
+### Generate RSA 4096 key pair for JWT signing/verification
+echo "Generating RSA 4096 key pair for JWT ..."
+
+TEMP_DIR=$(mktemp -d)
+openssl genrsa -out "$TEMP_DIR/private.pem" 4096 2>/dev/null
+openssl rsa -in "$TEMP_DIR/private.pem" -pubout -out "$TEMP_DIR/public.pem" 2>/dev/null
+
+# Convert to DER, then Base64-encode as single-line strings for .env storage
+JWT_PRIVATE_KEY=$(openssl pkcs8 -topk8 -nocrypt -in "$TEMP_DIR/private.pem" -outform DER | base64 -w 0)
+JWT_PUBLIC_KEY=$(openssl rsa -pubin -in "$TEMP_DIR/public.pem" -outform DER 2>/dev/null | base64 -w 0)
+
+rm -rf "$TEMP_DIR"
 
 ### Write .env file
 echo ".env file generation has started ..."
 
 cat > .env << ENDOFFILE
-JWT_SECRET_KEY=${JWT_SECRET_KEY}
+JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY}
+JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY}
 ENDOFFILE
 
 echo ".env file generation done."

--- a/infrastructure/bash/init_scripts/initialize_win.bat
+++ b/infrastructure/bash/init_scripts/initialize_win.bat
@@ -22,6 +22,8 @@ echo .env file generation has started ...
 (
     echo JWT_PRIVATE_KEY=%JWT_PRIVATE_KEY%
     echo JWT_PUBLIC_KEY=%JWT_PUBLIC_KEY%
+
+    echo ACTIVE_PROFILES=compose,dev
 ) > .env
 
 echo .env file generation done.

--- a/infrastructure/bash/init_scripts/initialize_win.bat
+++ b/infrastructure/bash/init_scripts/initialize_win.bat
@@ -1,18 +1,27 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 :: Log
 echo Project initialisation has started ...
 
-:: Generate JWT secret key using PowerShell
-echo Generating JWT secret key ...
-for /f %%i in ('powershell -NoProfile -Command "[System.BitConverter]::ToString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).Replace(\"-\",\"\").ToLower()"') do set JWT_SECRET_KEY=%%i
+:: Generate RSA 4096 key pair using PowerShell
+echo Generating RSA 4096 key pair for JWT ...
+
+for /f "delims=" %%i in ('powershell -NoProfile -Command ^
+    "$rsa = [System.Security.Cryptography.RSA]::Create(4096); ^
+    [System.Convert]::ToBase64String($rsa.ExportPkcs8PrivateKey())"') do set JWT_PRIVATE_KEY=%%i
+
+for /f "delims=" %%i in ('powershell -NoProfile -Command ^
+    "$rsa = [System.Security.Cryptography.RSA]::Create(4096); ^
+    $rsa.ImportPkcs8PrivateKey([System.Convert]::FromBase64String('%JWT_PRIVATE_KEY%'), [ref]$null); ^
+    [System.Convert]::ToBase64String($rsa.ExportSubjectPublicKeyInfo())"') do set JWT_PUBLIC_KEY=%%i
 
 :: Write .env file
 echo .env file generation has started ...
 
 (
-    echo JWT_SECRET_KEY=%JWT_SECRET_KEY%
+    echo JWT_PRIVATE_KEY=%JWT_PRIVATE_KEY%
+    echo JWT_PUBLIC_KEY=%JWT_PUBLIC_KEY%
 ) > .env
 
 echo .env file generation done.

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtConstants.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtConstants.java
@@ -1,0 +1,10 @@
+package com.marzuk.components.security;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JwtConstants {
+
+    public static final String KEY_ALGORITHM = "RSA";
+}

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtProperties.java
@@ -9,5 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-    private String secretKey;
+    private String publicKey;
+    private String privateKey;
 }

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
@@ -5,32 +5,57 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
 
 @Component
 public class JwtUtil {
 
-    private final SecretKey signingKey;
+    private final PublicKey publicKey;
+    private final PrivateKey privateKey;
 
     public JwtUtil(JwtProperties jwtProperties) {
-        this.signingKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            byte[] publicKeyBytes = Base64.getDecoder().decode(jwtProperties.getPublicKey());
+            this.publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
+
+            if (jwtProperties.getPrivateKey() != null && !jwtProperties.getPrivateKey().isBlank()) {
+                byte[] privateKeyBytes = Base64.getDecoder().decode(jwtProperties.getPrivateKey());
+                this.privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+            } else {
+                this.privateKey = null;
+            }
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new IllegalStateException("Failed to load RSA keys for JWT", exception);
+        }
+    }
+
+    public PrivateKey getSigningKey() {
+        if (privateKey == null) {
+            throw new IllegalStateException("JWT private key is not configured — this service cannot sign tokens");
+        }
+        return privateKey;
     }
 
     public Claims extractAllClaims(String token) {
         try {
             return Jwts.parser()
-                    .verifyWith(signingKey)
+                    .verifyWith(publicKey)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
         } catch (ExpiredJwtException exception) {
-            // Return embedded claims so callers can inspect expiry (e.g. isTokenExpired)
             return exception.getClaims();
         } catch (JwtException | IllegalArgumentException exception) {
             throw new UnauthorizedException("Invalid or malformed JWT token");

--- a/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
+++ b/lib/components/src/main/java/com/marzuk/components/security/JwtUtil.java
@@ -26,7 +26,7 @@ public class JwtUtil {
 
     public JwtUtil(JwtProperties jwtProperties) {
         try {
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            KeyFactory keyFactory = KeyFactory.getInstance(JwtConstants.KEY_ALGORITHM);
             byte[] publicKeyBytes = Base64.getDecoder().decode(jwtProperties.getPublicKey());
             this.publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
 

--- a/lib/components/src/test/java/com/marzuk/components/security/JwtUtilTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/security/JwtUtilTest.java
@@ -2,12 +2,14 @@ package com.marzuk.components.security;
 
 import com.marzuk.components.exception.UnauthorizedException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
 
@@ -16,18 +18,31 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JwtUtilTest {
 
-    private static final String SECRET_KEY = "test-secret-key-that-is-long-enough-for-hmac-sha256";
-    private static final String DIFFERENT_SECRET_KEY = "different-secret-key-that-is-long-enough-for-hmac";
+    private static KeyPair keyPair;
+    private static KeyPair differentKeyPair;
 
     private JwtUtil jwtUtil;
-    private SecretKey signingKey;
+    private PrivateKey signingKey;
+
+    @BeforeAll
+    static void generateKeys() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        keyPair = generator.generateKeyPair();
+        differentKeyPair = generator.generateKeyPair();
+    }
 
     @BeforeEach
     void setUp() {
+        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        String encodedPrivateKey = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+
         JwtProperties jwtProperties = new JwtProperties();
-        jwtProperties.setSecretKey(SECRET_KEY);
+        jwtProperties.setPublicKey(encodedPublicKey);
+        jwtProperties.setPrivateKey(encodedPrivateKey);
+
         jwtUtil = new JwtUtil(jwtProperties);
-        signingKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+        signingKey = keyPair.getPrivate();
     }
 
     private String buildValidToken(UUID userId, String role, String email) {
@@ -110,14 +125,45 @@ class JwtUtilTest {
 
     @Test
     void validateToken_throwsForWrongSigningKey() {
-        SecretKey differentKey = Keys.hmacShaKeyFor(DIFFERENT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
         String token = Jwts.builder()
                 .subject(UUID.randomUUID().toString())
                 .expiration(new Date(System.currentTimeMillis() + 60_000))
-                .signWith(differentKey)
+                .signWith(differentKeyPair.getPrivate())
                 .compact();
 
         assertThatThrownBy(() -> jwtUtil.validateToken(token))
                 .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void getSigningKey_returnsPrivateKeyWhenConfigured() {
+        assertThat(jwtUtil.getSigningKey()).isEqualTo(keyPair.getPrivate());
+    }
+
+    @Test
+    void constructor_succeedsWithoutPrivateKey() {
+        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+
+        JwtProperties verifyOnlyProperties = new JwtProperties();
+        verifyOnlyProperties.setPublicKey(encodedPublicKey);
+
+        JwtUtil verifyOnlyUtil = new JwtUtil(verifyOnlyProperties);
+
+        UUID userId = UUID.randomUUID();
+        String token = buildValidToken(userId, "USER", "user@example.com");
+        assertThat(verifyOnlyUtil.extractUserId(token)).isEqualTo(userId);
+    }
+
+    @Test
+    void getSigningKey_throwsWhenPrivateKeyNotConfigured() {
+        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+
+        JwtProperties verifyOnlyProperties = new JwtProperties();
+        verifyOnlyProperties.setPublicKey(encodedPublicKey);
+
+        JwtUtil verifyOnlyUtil = new JwtUtil(verifyOnlyProperties);
+
+        assertThatThrownBy(verifyOnlyUtil::getSigningKey)
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/packages/api-gateway/src/main/resources/application.yml
+++ b/packages/api-gateway/src/main/resources/application.yml
@@ -6,7 +6,7 @@ server:
   port: 8080
 
 jwt:
-  secretKey: ${JWT_SECRET_KEY}
+  public-key: ${JWT_PUBLIC_KEY}
 
 app:
   security:

--- a/packages/auth/src/main/resources/application.yml
+++ b/packages/auth/src/main/resources/application.yml
@@ -3,10 +3,11 @@ spring:
     name: auth
 
 server:
-  port: 8081
+  port: 8080
 
 jwt:
-  secretKey: ${JWT_SECRET_KEY}
+  public-key: ${JWT_PUBLIC_KEY}
+  private-key: ${JWT_PRIVATE_KEY}
 
 app:
   security:


### PR DESCRIPTION
## Related Issue
Closes: #172

## What I Did
- Replace shared HMAC symmetric secret (`JWT_SECRET_KEY`) with RSA 4096-bit asymmetric key pair
- Auth service uses private key for signing; gateway and other services use public key for verification only
- Update init script to generate RSA key pair and Base64-encode into `.env`
- Update `JwtProperties`, `JwtUtil`, and `JwtUtilTest` in `lib/components`

## Implementation Plan
See [docs/plan/task_plan_172.md](docs/plan/task_plan_172.md)

## How to Test
- Run `infrastructure/bash/init_scripts/initialize.sh` and verify `.env` contains `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY`
- Run `mvn test -pl lib/components` — all `JwtUtilTest` cases pass with RSA keys
- Start api-gateway with only `JWT_PUBLIC_KEY` set — verify it starts and validates tokens
- Start auth with both keys set — verify it starts

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes