### PR TITLE
Setup auth-service module (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 JWT_PRIVATE_KEY=replace-with-base64-encoded-rsa-private-key
 JWT_PUBLIC_KEY=replace-with-base64-encoded-rsa-public-key
 
+AUTH_DB_URL=replace-with-auth-db-url
+AUTH_DB_USERNAME=replace-with-auth-db-username
+AUTH_DB_PASSWORD=replace-with-auth-db-password
+
 ACTIVE_PROFILES=compose,dev

--- a/docs/plan/task_plan_39.md
+++ b/docs/plan/task_plan_39.md
@@ -1,0 +1,86 @@
+# Task Plan — Issue #39: Setup auth-service module
+
+## What
+
+Wire the existing `packages/auth` module so it can start successfully and connect to its dedicated `auth_db` PostgreSQL database. This is pure infrastructure configuration — no business logic, no entities, no controllers. Those belong to the blocking issues (#40, #41).
+
+## Note on config-server criterion
+
+The original acceptance criterion "Fetches config from config-server" is **obsolete** — issue #175 removed config-server in favour of k8s-native config (ConfigMaps/Secrets + env vars). The auth service already reads JWT keys from environment variables. No config-server dependency will be added.
+
+## Services / Layers Touched
+
+- `lib/rest-starter` — add PostgreSQL driver and Testcontainers PostgreSQL to the shared dependency bundle
+- `packages/auth` — update `application.yml` with datasource properties; no Java source changes
+- `.env.example` — document new env vars
+
+## Changes
+
+### 1. `lib/rest-starter/pom.xml`
+
+Add PostgreSQL driver (runtime scope) and Testcontainers PostgreSQL (test scope). Every REST microservice will connect to its own Postgres database, so the driver belongs in the shared starter rather than duplicated per-service.
+
+```xml
+<dependency>
+    <groupId>org.postgresql</groupId>
+    <artifactId>postgresql</artifactId>
+    <scope>runtime</scope>
+</dependency>
+
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>postgresql</artifactId>
+    <version>${testcontainers.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+### 2. `packages/auth/src/main/resources/application.yml`
+
+Add datasource and JPA configuration driven by environment variables:
+
+```yaml
+spring:
+  datasource:
+    url: ${AUTH_DB_URL:jdbc:postgresql://localhost:5432/auth_db}
+    username: ${AUTH_DB_USERNAME:postgres}
+    password: ${AUTH_DB_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:validate}
+    open-in-view: false
+```
+
+### 3. `.env.example`
+
+```
+AUTH_DB_URL=jdbc:postgresql://localhost:5432/auth_db
+AUTH_DB_USERNAME=postgres
+AUTH_DB_PASSWORD=postgres
+```
+
+## Reusable Components
+
+None — PostgreSQL driver is infrastructure-level and goes into `rest-starter` which is already the shared bundle.
+
+## Tests
+
+- **Unit tests**: none required — this is configuration only, no logic to unit test.
+- **Integration test**: one `@SpringBootTest` using Testcontainers PostgreSQL to verify:
+  - Application context loads without errors
+  - Datasource connects to `auth_db`
+  - `/actuator/health` returns `UP`
+
+## SOLID / KISS
+
+- **SRP**: each change has a single concern — `rest-starter` owns "what deps all REST services share", `application.yml` owns "how auth connects to its DB".
+- **KISS**: minimum viable wiring only. No Kafka, no entities, no security config beyond what already exists.
+
+## Acceptance Criteria Mapping
+
+| Criterion | How satisfied |
+|---|---|
+| Service starts on configured port | Port 8080 already in `application.yml`; datasource config unblocks startup |
+| Connects to `auth_db` | Datasource URL, username, password added via env vars |
+| Fetches config from config-server | Obsolete (config-server removed in #175) — env-var config already in place |
+| `/actuator/health` returns UP | Actuator already provided by `rest-starter`; `/actuator/health` already in public paths |

--- a/lib/rest-starter/pom.xml
+++ b/lib/rest-starter/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <java.version>21</java.version>
         <springdoc.version>2.6.0</springdoc.version>
-        <testcontainers.version>1.20.6</testcontainers.version>
+        <testcontainers.version>1.21.0</testcontainers.version>
         <mapstruct.version>1.6.3</mapstruct.version>
     </properties>
 
@@ -71,6 +71,19 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/packages/auth/pom.xml
+++ b/packages/auth/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <java.version>21</java.version>
+        <testcontainers.version>1.21.0</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -35,10 +36,44 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--
+                            Docker Engine 29.x raised its minimum supported API version to 1.40.
+                            docker-java defaults to 1.32 for version negotiation; set this to 1.41
+                            so the Testcontainers JVM can connect to the daemon.
+                        -->
+                        <api.version>1.41</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/packages/auth/src/main/resources/application.yml
+++ b/packages/auth/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   application:
     name: auth
+  datasource:
+    url: ${AUTH_DB_URL:jdbc:postgresql://localhost:5432/auth_db}
+    username: ${AUTH_DB_USERNAME:postgres}
+    password: ${AUTH_DB_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:validate}
+    open-in-view: false
 
 server:
   port: 8080

--- a/packages/auth/src/test/java/com/marzuk/auth/AuthAppIntegrationTest.java
+++ b/packages/auth/src/test/java/com/marzuk/auth/AuthAppIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.marzuk.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthAppIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("auth_db")
+            .withUsername("postgres")
+            .withPassword("postgres");
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        registry.add("jwt.public-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        registry.add("jwt.private-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
+    }
+
+    @Test
+    void applicationContext_loadsSuccessfully() {
+        // context loads without errors — verified by the fact that the test reaches this point
+    }
+
+    @Test
+    void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
+        ResponseEntity<Map> response = restTemplate.getForEntity(
+                "http://localhost:" + port + "/actuator/health", Map.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).containsEntry("status", "UP");
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes: #39

## What I Did
- Added PostgreSQL driver (runtime) and Testcontainers PostgreSQL (test) to `lib/rest-starter` so all REST microservices share the dependency
- Added datasource and JPA config to `packages/auth/src/main/resources/application.yml` driven by env vars (`AUTH_DB_URL`, `AUTH_DB_USERNAME`, `AUTH_DB_PASSWORD`)
- Updated `.env.example` with the new env vars
- Skipped config-server dependency — removed in #175 in favour of k8s-native config

## Implementation Plan
See [docs/plan/task_plan_39.md](docs/plan/task_plan_39.md)

## How to Test
- Set `AUTH_DB_URL`, `AUTH_DB_USERNAME`, `AUTH_DB_PASSWORD` (or use defaults pointing at a local Postgres)
- Run `mvn spring-boot:run -pl packages/auth`
- Hit `http://localhost:8080/actuator/health` — expect `{"status":"UP"}`
- Run integration test: `mvn test -pl packages/auth`

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes