### PR TITLE
Setup admin-portal module (#134)

### DIFF
--- a/docs/plan/task_plan_134.md
+++ b/docs/plan/task_plan_134.md
@@ -1,0 +1,68 @@
+# Task Plan — Issue #134: Setup admin-portal module
+
+## What
+Bootstrap the `admin-portal` Maven module under `packages/admin-portal/` as a stateless
+Thymeleaf MVC web UI. No JPA, no PostgreSQL, no direct database connection. All data access
+goes through API calls to downstream services (user-service, etc.). The service must start
+cleanly and expose a healthy `/actuator/health` endpoint.
+
+## Services / Modules touched
+- `packages/admin-portal/` — primary target
+- Root `pom.xml` — already declares `<module>packages/admin-portal</module>`; no change needed
+
+## Layers involved
+Bootstrap only — no business logic. Layers wired:
+- **Thymeleaf + Spring Web MVC** → via `web-starter`
+- **Spring Security** → protect admin routes; `/actuator/health` stays public
+- **Actuator** → via `web-starter`
+
+No JPA, no datasource, no Kafka, no Testcontainers.
+
+## Steps
+
+### 1. Update `packages/admin-portal/pom.xml`
+- Keep existing `web-starter` (pom type) — already bundles Thymeleaf, Validation, Actuator,
+  `components` JAR
+- Add:
+  - `spring-boot-starter-security`
+  - `maven-surefire-plugin` with `api.version=1.41` (Docker Engine 29.x compat)
+
+### 2. Create main application class
+`src/main/java/com/marzuk/adminportal/AdminPortalApp.java`
+- `@SpringBootApplication(scanBasePackages = {"com.marzuk.adminportal", "com.marzuk.components"}, exclude = {UserDetailsServiceAutoConfiguration.class})`
+- Lombok `@Slf4j` startup banner
+
+### 3. Create `application.yml`
+`src/main/resources/application.yml`
+- No datasource block
+- JWT: `JWT_PUBLIC_KEY` / `JWT_PRIVATE_KEY`
+- Server port: `8080`
+- Public paths: `/actuator/health`
+
+### 4. Create integration test
+`src/test/java/com/marzuk/adminportal/AdminPortalAppIntegrationTest.java`
+- Plain `@SpringBootTest` — no Testcontainers needed (no DB)
+- `@DynamicPropertySource`: generate RSA key pair for JWT
+- Tests: context loads + `/actuator/health` returns `UP`
+
+## Reusable components
+Everything reusable already lives in `lib/components`:
+- `SecurityConfig`, `JwtAuthenticationFilter`, `JwtUtil`
+- `BaseEntity`, `EventEnvelope<T>`, exception hierarchy, `GlobalExceptionHandler`
+
+No new additions to `lib/` are needed for this issue.
+
+## SOLID alignment
+- **SRP**: portal has no data ownership; all persistence delegated to backend services via API
+- **DIP**: security injected from `lib/components`; API clients (RestTemplate/WebClient) will
+  be wired in later issues
+
+## KISS check
+- No JPA, PostgreSQL, Kafka, or Testcontainers — none of these belong in a pure MVC frontend
+- No API client bean yet — that comes when actual admin screens are built (#136–#137)
+
+## Test plan
+| Test | Type | Verifies |
+|---|---|---|
+| Context loads | `@SpringBootTest` (no containers) | All auto-config wires correctly |
+| `/actuator/health` returns UP | `@SpringBootTest` | Actuator exposed and healthy |

--- a/packages/admin-portal/pom.xml
+++ b/packages/admin-portal/pom.xml
@@ -31,10 +31,36 @@
             <version>0.0.1</version>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--
+                            Docker Engine 29.x raised its minimum supported API version to 1.40.
+                            docker-java defaults to 1.32 for version negotiation; set this to 1.41
+                            so the Testcontainers JVM can connect to the daemon.
+                        -->
+                        <api.version>1.41</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/packages/admin-portal/src/main/java/com/marzuk/adminportal/AdminPortalApp.java
+++ b/packages/admin-portal/src/main/java/com/marzuk/adminportal/AdminPortalApp.java
@@ -1,0 +1,21 @@
+package com.marzuk.adminportal;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+
+@Slf4j
+@SpringBootApplication(
+        scanBasePackages = {"com.marzuk.adminportal", "com.marzuk.components"},
+        exclude = {UserDetailsServiceAutoConfiguration.class}
+)
+public class AdminPortalApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AdminPortalApp.class, args);
+        log.info("###################################");
+        log.info("Admin portal started successfully!!!");
+        log.info("###################################");
+    }
+}

--- a/packages/admin-portal/src/main/resources/application.yml
+++ b/packages/admin-portal/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: admin-portal
+
+server:
+  port: 8080
+
+jwt:
+  public-key: ${JWT_PUBLIC_KEY}
+  private-key: ${JWT_PRIVATE_KEY}
+
+app:
+  security:
+    public-paths:
+      - /actuator/health

--- a/packages/admin-portal/src/test/java/com/marzuk/adminportal/AdminPortalAppIntegrationTest.java
+++ b/packages/admin-portal/src/test/java/com/marzuk/adminportal/AdminPortalAppIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.marzuk.adminportal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AdminPortalAppIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        registry.add("jwt.public-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        registry.add("jwt.private-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
+    }
+
+    @Test
+    void applicationContext_loadsSuccessfully() {
+        // context loads without errors — verified by the fact that the test reaches this point
+    }
+
+    @Test
+    void actuatorHealth_returnsUp() {
+        ResponseEntity<Map> response = restTemplate.getForEntity(
+                "http://localhost:" + port + "/actuator/health", Map.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).containsEntry("status", "UP");
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes: #134

## What I Did
- Bootstrap `admin-portal` as a pure Thymeleaf MVC web UI with no direct DB dependency
- Add Spring Security; public paths limited to `/actuator/health`
- Reuse `SecurityConfig` and `JwtAuthenticationFilter` from `lib/components` via component scanning

## How to Test
- Run `mvn clean package -pl packages/admin-portal -am`
- Verify context loads and `/actuator/health` returns `UP`

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes

---
Implementation plan: [docs/plan/task_plan_134.md](docs/plan/task_plan_134.md)