### PR TITLE
feat: add infrastructure bash scripts (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ logs/
 .env.local
 *.pem
 *.key
+.secrets/

--- a/docs/plan/task_plan_33.md
+++ b/docs/plan/task_plan_33.md
@@ -1,0 +1,91 @@
+# Task Plan — Issue #33: Create Infrastructure Bash Scripts
+
+## What
+
+Create DevOps shell scripts under `infrastructure/bash/` to automate Docker image builds/pushes,
+local service health monitoring, and code-format enforcement via a git pre-commit hook.
+Also wire the Spotless Maven plugin (Google Java Format) into the root `pom.xml` so the hook
+has something to invoke.
+
+## Scope
+
+**Infrastructure only** — no service code is touched.
+
+| Deliverable | Path |
+|---|---|
+| Spotless plugin | `pom.xml` (root `<build>`) |
+| Release image push | `infrastructure/bash/push_images/push_release.sh` |
+| Snapshot image push | `infrastructure/bash/push_images/push_snapshot.sh` |
+| Service health monitor | `infrastructure/bash/monitor.sh` |
+| Pre-commit hook | `infrastructure/bash/git_hooks/pre-commit` |
+| `.gitignore` update | `.gitignore` (add `.secrets/`) |
+
+Scripts that already exist (`initialize.sh`, `initialize_win.bat`) are **out of scope**.
+
+## Design
+
+### `pom.xml` — Spotless Plugin
+
+Add `com.diffplug.spotless:spotless-maven-plugin:2.43.0` to the root aggregator's
+`<build><plugins>` block with `<inherited>false</inherited>`.
+
+Configuration:
+- **Google Java Format 1.22.0** (AOSP style, 4-space indent)
+- Source globs cover `lib/**/src/{main,test}/java/**/*.java` and `packages/**/src/{main,test}/java/**/*.java`
+- `<removeUnusedImports/>` enabled
+
+Developers run:
+- `mvn spotless:check` — fails if any file is mis-formatted
+- `mvn spotless:apply` — auto-fixes formatting in place
+
+### `git_hooks/pre-commit`
+
+```sh
+#!/bin/sh
+set -e
+echo "Running Spotless formatter check ..."
+mvn spotless:check -q
+echo "Formatter check passed."
+```
+
+Must be executable. Installed to `.git/hooks/` via `initialize.sh` (existing script, future work).
+
+### `push_images/push_release.sh`
+
+1. `mvn clean package -DskipTests` — build all JARs
+2. `git describe --tags --abbrev=0` — get latest tag (e.g. `v1.2.0`)
+3. Strip leading `v`, export as `TAG`
+4. `docker compose build --no-cache`
+5. `docker compose push`
+
+Assumes `docker-compose.yml` at project root uses `${TAG}` in image names.
+
+### `push_images/push_snapshot.sh`
+
+Same flow but `TAG=$(git rev-parse --short HEAD)` instead of a git tag.
+
+### `monitor.sh`
+
+Configurable port map at the top (edit to match `docker-compose.yml` port bindings):
+
+```
+AUTH_PORT=8081, USER_PORT=8082, CHAT_PORT=8083,
+NOTIFICATION_PORT=8084, STORAGE_PORT=8085,
+API_GATEWAY_PORT=8086, ADMIN_PORTAL_PORT=8087
+```
+
+For each service:
+- `curl -sf http://localhost:${PORT}/actuator/health/liveness`
+- Print `[ UP ]` (green) or `[DOWN]` (red)
+- Summary line: `X/7 services UP`
+
+## Tests
+
+These are shell scripts and Maven config — no unit tests apply.
+
+Manual verification:
+1. `mvn spotless:check` passes on clean checkout
+2. Introduce a formatting violation → `mvn spotless:check` fails; `mvn spotless:apply` fixes it
+3. `./infrastructure/bash/monitor.sh` — shows `[DOWN]` for all services when nothing is running
+4. Pre-commit hook blocks a commit that contains mis-formatted Java
+5. Push scripts are tested once `docker-compose.yml` is created (future issue)

--- a/infrastructure/bash/git_hooks/pre-commit
+++ b/infrastructure/bash/git_hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+echo "Running Spotless formatter check ..."
+mvn spotless:check -q
+echo "Formatter check passed."

--- a/infrastructure/bash/monitor.sh
+++ b/infrastructure/bash/monitor.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Edit these ports to match docker-compose.yml bindings.
+AUTH_PORT=8081
+USER_PORT=8082
+CHAT_PORT=8083
+NOTIFICATION_PORT=8084
+STORAGE_PORT=8085
+API_GATEWAY_PORT=8086
+ADMIN_PORTAL_PORT=8087
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+check_service() {
+    local name=$1
+    local port=$2
+    if curl -sf "http://localhost:${port}/actuator/health/liveness" > /dev/null 2>&1; then
+        echo -e "${GREEN}[ UP ]${RESET} ${name} (port ${port})"
+        return 0
+    else
+        echo -e "${RED}[DOWN]${RESET} ${name} (port ${port})"
+        return 1
+    fi
+}
+
+up=0
+
+check_service "auth"         "$AUTH_PORT"         && ((up++)) || true
+check_service "user"         "$USER_PORT"         && ((up++)) || true
+check_service "chat"         "$CHAT_PORT"         && ((up++)) || true
+check_service "notification" "$NOTIFICATION_PORT" && ((up++)) || true
+check_service "storage"      "$STORAGE_PORT"      && ((up++)) || true
+check_service "api-gateway"  "$API_GATEWAY_PORT"  && ((up++)) || true
+check_service "admin-portal" "$ADMIN_PORTAL_PORT" && ((up++)) || true
+
+echo ""
+echo "${up}/7 services UP"

--- a/infrastructure/bash/push_images/push_release.sh
+++ b/infrastructure/bash/push_images/push_release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Building all JARs ..."
+mvn clean package -DskipTests
+
+TAG=$(git describe --tags --abbrev=0)
+TAG=${TAG#v}
+export TAG
+
+echo "Releasing images with tag: $TAG"
+docker compose build --no-cache
+docker compose push
+
+echo "Done. Images pushed with tag: $TAG"

--- a/infrastructure/bash/push_images/push_snapshot.sh
+++ b/infrastructure/bash/push_images/push_snapshot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Building all JARs ..."
+mvn clean package -DskipTests
+
+TAG=$(git rev-parse --short HEAD)
+export TAG
+
+echo "Releasing snapshot images with tag: $TAG"
+docker compose build --no-cache
+docker compose push
+
+echo "Done. Images pushed with tag: $TAG"

--- a/lib/authorizer/src/main/java/com/marzuk/authorizer/AuthorizerAutoConfiguration.java
+++ b/lib/authorizer/src/main/java/com/marzuk/authorizer/AuthorizerAutoConfiguration.java
@@ -27,24 +27,31 @@ public class AuthorizerAutoConfiguration {
     static class GatewaySecurityConfig {
 
         @Bean
-        public GatewayJwtFilter gatewayJwtFilter(JwtUtil jwtUtil, AuthorizerProperties authorizerProperties,
-                                                 ObjectMapper objectMapper) {
+        public GatewayJwtFilter gatewayJwtFilter(
+                JwtUtil jwtUtil,
+                AuthorizerProperties authorizerProperties,
+                ObjectMapper objectMapper) {
             return new GatewayJwtFilter(jwtUtil, authorizerProperties, objectMapper);
         }
 
         @Bean
-        public SecurityFilterChain gatewaySecurityFilterChain(HttpSecurity http,
-                                                              AuthorizerProperties authorizerProperties,
-                                                              GatewayJwtFilter gatewayJwtFilter) throws Exception {
+        public SecurityFilterChain gatewaySecurityFilterChain(
+                HttpSecurity http,
+                AuthorizerProperties authorizerProperties,
+                GatewayJwtFilter gatewayJwtFilter)
+                throws Exception {
             String[] publicPaths = authorizerProperties.getPublicPaths().toArray(new String[0]);
 
-            return http
-                    .csrf(AbstractHttpConfigurer::disable)
-                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                    .authorizeHttpRequests(requests -> requests
-                            .requestMatchers(publicPaths).permitAll()
-                            .anyRequest().authenticated()
-                    )
+            return http.csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(
+                            session ->
+                                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(
+                            requests ->
+                                    requests.requestMatchers(publicPaths)
+                                            .permitAll()
+                                            .anyRequest()
+                                            .authenticated())
                     .addFilterBefore(gatewayJwtFilter, UsernamePasswordAuthenticationFilter.class)
                     .build();
         }
@@ -55,24 +62,31 @@ public class AuthorizerAutoConfiguration {
     static class WebSecurityConfig {
 
         @Bean
-        public WebCookieJwtFilter webCookieJwtFilter(JwtUtil jwtUtil, AuthorizerProperties authorizerProperties,
-                                                     ObjectMapper objectMapper) {
+        public WebCookieJwtFilter webCookieJwtFilter(
+                JwtUtil jwtUtil,
+                AuthorizerProperties authorizerProperties,
+                ObjectMapper objectMapper) {
             return new WebCookieJwtFilter(jwtUtil, authorizerProperties, objectMapper);
         }
 
         @Bean
-        public SecurityFilterChain webSecurityFilterChain(HttpSecurity http,
-                                                          AuthorizerProperties authorizerProperties,
-                                                          WebCookieJwtFilter webCookieJwtFilter) throws Exception {
+        public SecurityFilterChain webSecurityFilterChain(
+                HttpSecurity http,
+                AuthorizerProperties authorizerProperties,
+                WebCookieJwtFilter webCookieJwtFilter)
+                throws Exception {
             String[] publicPaths = authorizerProperties.getPublicPaths().toArray(new String[0]);
 
-            return http
-                    .csrf(AbstractHttpConfigurer::disable)
-                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                    .authorizeHttpRequests(requests -> requests
-                            .requestMatchers(publicPaths).permitAll()
-                            .anyRequest().authenticated()
-                    )
+            return http.csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(
+                            session ->
+                                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(
+                            requests ->
+                                    requests.requestMatchers(publicPaths)
+                                            .permitAll()
+                                            .anyRequest()
+                                            .authenticated())
                     .addFilterBefore(webCookieJwtFilter, UsernamePasswordAuthenticationFilter.class)
                     .build();
         }

--- a/lib/authorizer/src/main/java/com/marzuk/authorizer/AuthorizerProperties.java
+++ b/lib/authorizer/src/main/java/com/marzuk/authorizer/AuthorizerProperties.java
@@ -1,11 +1,10 @@
 package com.marzuk.authorizer;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Setter
@@ -17,6 +16,7 @@ public class AuthorizerProperties {
     private String cookieName = "jwt";
 
     public enum Mode {
-        GATEWAY, WEB
+        GATEWAY,
+        WEB
     }
 }

--- a/lib/authorizer/src/main/java/com/marzuk/authorizer/GatewayJwtFilter.java
+++ b/lib/authorizer/src/main/java/com/marzuk/authorizer/GatewayJwtFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -16,9 +18,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.List;
 
 @RequiredArgsConstructor
 public class GatewayJwtFilter extends OncePerRequestFilter {
@@ -32,7 +31,8 @@ public class GatewayJwtFilter extends OncePerRequestFilter {
     private static final String ROLE_CLAIM = "role";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
         if (isPublicPath(request.getRequestURI())) {
@@ -51,8 +51,9 @@ public class GatewayJwtFilter extends OncePerRequestFilter {
             Claims claims = jwtUtil.validateToken(token);
             String userId = claims.getSubject();
             String role = claims.get(ROLE_CLAIM, String.class);
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userId, null, List.of(new SimpleGrantedAuthority(role)));
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId, null, List.of(new SimpleGrantedAuthority(role)));
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (UnauthorizedException exception) {
             writeUnauthorized(response);

--- a/lib/authorizer/src/main/java/com/marzuk/authorizer/JwtUtil.java
+++ b/lib/authorizer/src/main/java/com/marzuk/authorizer/JwtUtil.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -30,7 +29,8 @@ public class JwtUtil {
 
             if (jwtProperties.getPrivateKey() != null && !jwtProperties.getPrivateKey().isBlank()) {
                 byte[] privateKeyBytes = Base64.getDecoder().decode(jwtProperties.getPrivateKey());
-                this.privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+                this.privateKey =
+                        keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
             } else {
                 this.privateKey = null;
             }
@@ -41,7 +41,8 @@ public class JwtUtil {
 
     public PrivateKey getSigningKey() {
         if (privateKey == null) {
-            throw new IllegalStateException("JWT private key is not configured — this service cannot sign tokens");
+            throw new IllegalStateException(
+                    "JWT private key is not configured — this service cannot sign tokens");
         }
         return privateKey;
     }

--- a/lib/authorizer/src/main/java/com/marzuk/authorizer/WebCookieJwtFilter.java
+++ b/lib/authorizer/src/main/java/com/marzuk/authorizer/WebCookieJwtFilter.java
@@ -9,6 +9,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,11 +20,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 public class WebCookieJwtFilter extends OncePerRequestFilter {
@@ -33,7 +32,8 @@ public class WebCookieJwtFilter extends OncePerRequestFilter {
     private static final String ROLE_CLAIM = "role";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
         if (isPublicPath(request.getRequestURI())) {
@@ -51,8 +51,9 @@ public class WebCookieJwtFilter extends OncePerRequestFilter {
             Claims claims = jwtUtil.validateToken(token.get());
             String userId = claims.getSubject();
             String role = claims.get(ROLE_CLAIM, String.class);
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userId, null, List.of(new SimpleGrantedAuthority(role)));
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId, null, List.of(new SimpleGrantedAuthority(role)));
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (UnauthorizedException exception) {
             writeUnauthorized(response);

--- a/lib/authorizer/src/test/java/com/marzuk/authorizer/AutoConfigurationTest.java
+++ b/lib/authorizer/src/test/java/com/marzuk/authorizer/AutoConfigurationTest.java
@@ -1,16 +1,15 @@
 package com.marzuk.authorizer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPairGenerator;
+import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
-
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AutoConfigurationTest {
 
@@ -27,12 +26,14 @@ class AutoConfigurationTest {
         }
     }
 
-    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(
-                    JacksonAutoConfiguration.class,
-                    WebMvcAutoConfiguration.class,
-                    SecurityAutoConfiguration.class,
-                    AuthorizerAutoConfiguration.class));
+    private final WebApplicationContextRunner contextRunner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    JacksonAutoConfiguration.class,
+                                    WebMvcAutoConfiguration.class,
+                                    SecurityAutoConfiguration.class,
+                                    AuthorizerAutoConfiguration.class));
 
     @Test
     void gatewayMode_createsGatewayFilterAndJwtUtil() {
@@ -40,13 +41,13 @@ class AutoConfigurationTest {
                 .withPropertyValues(
                         "app.authorizer.mode=gateway",
                         "app.authorizer.public-paths=/api/auth/**,/actuator/health",
-                        "jwt.public-key=" + PUBLIC_KEY
-                )
-                .run(context -> {
-                    assertThat(context).hasSingleBean(JwtUtil.class);
-                    assertThat(context).hasSingleBean(GatewayJwtFilter.class);
-                    assertThat(context).doesNotHaveBean(WebCookieJwtFilter.class);
-                });
+                        "jwt.public-key=" + PUBLIC_KEY)
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(JwtUtil.class);
+                            assertThat(context).hasSingleBean(GatewayJwtFilter.class);
+                            assertThat(context).doesNotHaveBean(WebCookieJwtFilter.class);
+                        });
     }
 
     @Test
@@ -56,29 +57,29 @@ class AutoConfigurationTest {
                         "app.authorizer.mode=web",
                         "app.authorizer.public-paths=/login,/actuator/health",
                         "app.authorizer.cookie-name=jwt",
-                        "jwt.public-key=" + PUBLIC_KEY
-                )
-                .run(context -> {
-                    assertThat(context).hasSingleBean(JwtUtil.class);
-                    assertThat(context).hasSingleBean(WebCookieJwtFilter.class);
-                    assertThat(context).doesNotHaveBean(GatewayJwtFilter.class);
-                });
+                        "jwt.public-key=" + PUBLIC_KEY)
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(JwtUtil.class);
+                            assertThat(context).hasSingleBean(WebCookieJwtFilter.class);
+                            assertThat(context).doesNotHaveBean(GatewayJwtFilter.class);
+                        });
     }
 
     @Test
     void noMode_createsNeitherFilter() {
         contextRunner
                 .withPropertyValues("jwt.public-key=" + PUBLIC_KEY)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(JwtUtil.class);
-                    assertThat(context).doesNotHaveBean(GatewayJwtFilter.class);
-                    assertThat(context).doesNotHaveBean(WebCookieJwtFilter.class);
-                });
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(JwtUtil.class);
+                            assertThat(context).doesNotHaveBean(GatewayJwtFilter.class);
+                            assertThat(context).doesNotHaveBean(WebCookieJwtFilter.class);
+                        });
     }
 
     @Test
     void noPublicKey_doesNotCreateJwtUtil() {
-        contextRunner
-                .run(context -> assertThat(context).doesNotHaveBean(JwtUtil.class));
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(JwtUtil.class));
     }
 }

--- a/lib/authorizer/src/test/java/com/marzuk/authorizer/GatewayJwtFilterTest.java
+++ b/lib/authorizer/src/test/java/com/marzuk/authorizer/GatewayJwtFilterTest.java
@@ -1,9 +1,14 @@
 package com.marzuk.authorizer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marzuk.components.exception.UnauthorizedException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,23 +19,14 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class GatewayJwtFilterTest {
 
-    @Mock
-    private JwtUtil jwtUtil;
+    @Mock private JwtUtil jwtUtil;
 
-    @Mock
-    private FilterChain filterChain;
+    @Mock private FilterChain filterChain;
 
-    @Mock
-    private Claims claims;
+    @Mock private Claims claims;
 
     private GatewayJwtFilter filter;
 
@@ -39,7 +35,9 @@ class GatewayJwtFilterTest {
         AuthorizerProperties authorizerProperties = new AuthorizerProperties();
         authorizerProperties.setPublicPaths(List.of("/api/auth/login", "/api/auth/register"));
 
-        filter = new GatewayJwtFilter(jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
+        filter =
+                new GatewayJwtFilter(
+                        jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
     }
 
     @AfterEach
@@ -108,7 +106,8 @@ class GatewayJwtFilterTest {
         request.addHeader("Authorization", "Bearer " + token);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        given(jwtUtil.validateToken(token)).willThrow(new UnauthorizedException("JWT token has expired"));
+        given(jwtUtil.validateToken(token))
+                .willThrow(new UnauthorizedException("JWT token has expired"));
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -126,7 +125,8 @@ class GatewayJwtFilterTest {
         request.addHeader("Authorization", "Bearer " + token);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        given(jwtUtil.validateToken(token)).willThrow(new UnauthorizedException("Invalid or malformed JWT token"));
+        given(jwtUtil.validateToken(token))
+                .willThrow(new UnauthorizedException("Invalid or malformed JWT token"));
 
         filter.doFilterInternal(request, response, filterChain);
 
@@ -152,7 +152,9 @@ class GatewayJwtFilterTest {
     void publicPathWithAntPattern_skipsFilter() throws Exception {
         AuthorizerProperties authorizerProperties = new AuthorizerProperties();
         authorizerProperties.setPublicPaths(List.of("/api/auth/**"));
-        filter = new GatewayJwtFilter(jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
+        filter =
+                new GatewayJwtFilter(
+                        jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/api/auth/refresh");

--- a/lib/authorizer/src/test/java/com/marzuk/authorizer/JwtUtilTest.java
+++ b/lib/authorizer/src/test/java/com/marzuk/authorizer/JwtUtilTest.java
@@ -1,20 +1,19 @@
 package com.marzuk.authorizer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.marzuk.components.exception.UnauthorizedException;
 import io.jsonwebtoken.Jwts;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class JwtUtilTest {
 
@@ -34,8 +33,10 @@ class JwtUtilTest {
 
     @BeforeEach
     void setUp() {
-        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        String encodedPrivateKey = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+        String encodedPublicKey =
+                Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        String encodedPrivateKey =
+                Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
 
         JwtProperties jwtProperties = new JwtProperties();
         jwtProperties.setPublicKey(encodedPublicKey);
@@ -125,11 +126,12 @@ class JwtUtilTest {
 
     @Test
     void validateToken_throwsForWrongSigningKey() {
-        String token = Jwts.builder()
-                .subject(UUID.randomUUID().toString())
-                .expiration(new Date(System.currentTimeMillis() + 60_000))
-                .signWith(differentKeyPair.getPrivate())
-                .compact();
+        String token =
+                Jwts.builder()
+                        .subject(UUID.randomUUID().toString())
+                        .expiration(new Date(System.currentTimeMillis() + 60_000))
+                        .signWith(differentKeyPair.getPrivate())
+                        .compact();
 
         assertThatThrownBy(() -> jwtUtil.validateToken(token))
                 .isInstanceOf(UnauthorizedException.class);
@@ -142,7 +144,8 @@ class JwtUtilTest {
 
     @Test
     void constructor_succeedsWithoutPrivateKey() {
-        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        String encodedPublicKey =
+                Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
 
         JwtProperties verifyOnlyProperties = new JwtProperties();
         verifyOnlyProperties.setPublicKey(encodedPublicKey);
@@ -156,14 +159,14 @@ class JwtUtilTest {
 
     @Test
     void getSigningKey_throwsWhenPrivateKeyNotConfigured() {
-        String encodedPublicKey = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        String encodedPublicKey =
+                Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
 
         JwtProperties verifyOnlyProperties = new JwtProperties();
         verifyOnlyProperties.setPublicKey(encodedPublicKey);
 
         JwtUtil verifyOnlyUtil = new JwtUtil(verifyOnlyProperties);
 
-        assertThatThrownBy(verifyOnlyUtil::getSigningKey)
-                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(verifyOnlyUtil::getSigningKey).isInstanceOf(IllegalStateException.class);
     }
 }

--- a/lib/authorizer/src/test/java/com/marzuk/authorizer/WebCookieJwtFilterTest.java
+++ b/lib/authorizer/src/test/java/com/marzuk/authorizer/WebCookieJwtFilterTest.java
@@ -1,10 +1,15 @@
 package com.marzuk.authorizer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marzuk.components.exception.UnauthorizedException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,23 +20,14 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class WebCookieJwtFilterTest {
 
-    @Mock
-    private JwtUtil jwtUtil;
+    @Mock private JwtUtil jwtUtil;
 
-    @Mock
-    private FilterChain filterChain;
+    @Mock private FilterChain filterChain;
 
-    @Mock
-    private Claims claims;
+    @Mock private Claims claims;
 
     private WebCookieJwtFilter filter;
 
@@ -41,7 +37,9 @@ class WebCookieJwtFilterTest {
         authorizerProperties.setPublicPaths(List.of("/login", "/actuator/health"));
         authorizerProperties.setCookieName("jwt");
 
-        filter = new WebCookieJwtFilter(jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
+        filter =
+                new WebCookieJwtFilter(
+                        jwtUtil, authorizerProperties, new ObjectMapper().findAndRegisterModules());
     }
 
     @AfterEach
@@ -110,7 +108,8 @@ class WebCookieJwtFilterTest {
         request.setCookies(new Cookie("jwt", token));
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        given(jwtUtil.validateToken(token)).willThrow(new UnauthorizedException("JWT token has expired"));
+        given(jwtUtil.validateToken(token))
+                .willThrow(new UnauthorizedException("JWT token has expired"));
 
         filter.doFilterInternal(request, response, filterChain);
 

--- a/lib/components/src/main/java/com/marzuk/components/exception/handler/GlobalExceptionHandler.java
+++ b/lib/components/src/main/java/com/marzuk/components/exception/handler/GlobalExceptionHandler.java
@@ -2,39 +2,35 @@ package com.marzuk.components.exception.handler;
 
 import com.marzuk.components.exception.AppException;
 import com.marzuk.components.pojos.response.Response;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(AppException.class)
     public ResponseEntity<Response<Void>> handleAppException(AppException exception) {
-        return ResponseEntity
-                .status(exception.getStatus())
+        return ResponseEntity.status(exception.getStatus())
                 .body(Response.error(exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Response<Void>> handleValidation(MethodArgumentNotValidException exception) {
-        List<String> errors = exception.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .toList();
+    public ResponseEntity<Response<Void>> handleValidation(
+            MethodArgumentNotValidException exception) {
+        List<String> errors =
+                exception.getBindingResult().getFieldErrors().stream()
+                        .map(FieldError::getDefaultMessage)
+                        .toList();
 
-        return ResponseEntity
-                .badRequest()
-                .body(Response.error("Validation failed", errors));
+        return ResponseEntity.badRequest().body(Response.error("Validation failed", errors));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleGeneric(Exception exception) {
-        return ResponseEntity
-                .internalServerError()
-                .body(Response.error("Internal server error"));
+        return ResponseEntity.internalServerError().body(Response.error("Internal server error"));
     }
 }

--- a/lib/components/src/main/java/com/marzuk/components/kafka/EventEnvelope.java
+++ b/lib/components/src/main/java/com/marzuk/components/kafka/EventEnvelope.java
@@ -2,14 +2,13 @@ package com.marzuk.components.kafka;
 
 import com.marzuk.components.pojos.enums.EventSource;
 import com.marzuk.components.pojos.enums.EventType;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.Instant;
-import java.util.UUID;
 
 @Getter
 @Setter

--- a/lib/components/src/main/java/com/marzuk/components/kafka/EventEnvelopeDeserializer.java
+++ b/lib/components/src/main/java/com/marzuk/components/kafka/EventEnvelopeDeserializer.java
@@ -20,8 +20,11 @@ public class EventEnvelopeDeserializer implements Deserializer<EventEnvelope<?>>
         }
         try {
             // Deserialize payload as JsonNode so each consumer can convert to its own type
-            return objectMapper.readValue(data, objectMapper.getTypeFactory()
-                    .constructParametricType(EventEnvelope.class, JsonNode.class));
+            return objectMapper.readValue(
+                    data,
+                    objectMapper
+                            .getTypeFactory()
+                            .constructParametricType(EventEnvelope.class, JsonNode.class));
         } catch (Exception exception) {
             throw new RuntimeException("Failed to deserialize EventEnvelope", exception);
         }

--- a/lib/components/src/main/java/com/marzuk/components/pojos/dto/user/UserSummaryDTO.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/dto/user/UserSummaryDTO.java
@@ -1,11 +1,10 @@
 package com.marzuk.components.pojos.dto.user;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 @Data
 @Builder

--- a/lib/components/src/main/java/com/marzuk/components/pojos/entity/BaseEntity.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/entity/BaseEntity.java
@@ -5,13 +5,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.Instant;
-import java.util.UUID;
 
 @Getter
 @MappedSuperclass

--- a/lib/components/src/main/java/com/marzuk/components/pojos/response/PageResponse.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/response/PageResponse.java
@@ -1,10 +1,9 @@
 package com.marzuk.components.pojos.response;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
-
-import java.util.List;
 
 @Getter
 @Builder

--- a/lib/components/src/main/java/com/marzuk/components/pojos/response/Response.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/response/Response.java
@@ -1,10 +1,9 @@
 package com.marzuk.components.pojos.response;
 
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.Instant;
 import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @Builder
@@ -17,11 +16,7 @@ public class Response<T> {
     private List<String> errors;
 
     public static <T> Response<T> success(T data) {
-        return Response.<T>builder()
-                .success(true)
-                .data(data)
-                .timestamp(Instant.now())
-                .build();
+        return Response.<T>builder().success(true).data(data).timestamp(Instant.now()).build();
     }
 
     public static <T> Response<T> error(String message) {

--- a/lib/components/src/test/java/com/marzuk/components/TestConfig.java
+++ b/lib/components/src/test/java/com/marzuk/components/TestConfig.java
@@ -3,5 +3,4 @@ package com.marzuk.components;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-class TestConfig {
-}
+class TestConfig {}

--- a/lib/components/src/test/java/com/marzuk/components/exception/AppExceptionTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/exception/AppExceptionTest.java
@@ -1,9 +1,9 @@
 package com.marzuk.components.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AppExceptionTest {
 
@@ -25,7 +25,8 @@ class AppExceptionTest {
 
     @Test
     void duplicateResourceException_hasConflictStatus() {
-        DuplicateResourceException exception = new DuplicateResourceException("Email already exists");
+        DuplicateResourceException exception =
+                new DuplicateResourceException("Email already exists");
 
         assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT);
         assertThat(exception.getMessage()).isEqualTo("Email already exists");

--- a/lib/components/src/test/java/com/marzuk/components/exception/GlobalExceptionHandlerTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,7 @@
 package com.marzuk.components.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.marzuk.components.exception.handler.GlobalExceptionHandler;
 import com.marzuk.components.pojos.response.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,8 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class GlobalExceptionHandlerTest {
 
@@ -48,10 +48,13 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleValidation_returnsBadRequestWithFieldErrors() {
-        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "target");
+        BeanPropertyBindingResult bindingResult =
+                new BeanPropertyBindingResult(new Object(), "target");
         bindingResult.addError(new FieldError("target", "email", "must not be blank"));
-        bindingResult.addError(new FieldError("target", "password", "size must be between 8 and 64"));
-        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(null, bindingResult);
+        bindingResult.addError(
+                new FieldError("target", "password", "size must be between 8 and 64"));
+        MethodArgumentNotValidException exception =
+                new MethodArgumentNotValidException(null, bindingResult);
 
         ResponseEntity<Response<Void>> response = handler.handleValidation(exception);
 

--- a/lib/components/src/test/java/com/marzuk/components/kafka/EventEnvelopeSerializerTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/kafka/EventEnvelopeSerializerTest.java
@@ -1,14 +1,13 @@
 package com.marzuk.components.kafka;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marzuk.components.pojos.enums.EventSource;
 import com.marzuk.components.pojos.enums.EventType;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class EventEnvelopeSerializerTest {
 
@@ -37,7 +36,8 @@ class EventEnvelopeSerializerTest {
 
     @Test
     void roundTrip_withStringPayload() {
-        EventEnvelope<String> original = EventEnvelope.of(EventType.USER_REGISTERED, EventSource.AUTH, "user-123");
+        EventEnvelope<String> original =
+                EventEnvelope.of(EventType.USER_REGISTERED, EventSource.AUTH, "user-123");
 
         byte[] bytes = serializer.serialize("test-topic", original);
         EventEnvelope<?> deserialized = deserializer.deserialize("test-topic", bytes);
@@ -53,7 +53,8 @@ class EventEnvelopeSerializerTest {
     @Test
     void roundTrip_withMapPayload() {
         Map<String, Object> payloadData = Map.of("userId", "abc", "action", "login");
-        EventEnvelope<Map<String, Object>> original = EventEnvelope.of(EventType.USER_LOCKED, EventSource.AUTH, payloadData);
+        EventEnvelope<Map<String, Object>> original =
+                EventEnvelope.of(EventType.USER_LOCKED, EventSource.AUTH, payloadData);
 
         byte[] bytes = serializer.serialize("test-topic", original);
         EventEnvelope<?> deserialized = deserializer.deserialize("test-topic", bytes);
@@ -67,7 +68,8 @@ class EventEnvelopeSerializerTest {
     @Test
     void roundTrip_withCustomPojoPayload() {
         UserCreatedPayload payloadData = new UserCreatedPayload("user-42", "alice@example.com");
-        EventEnvelope<UserCreatedPayload> original = EventEnvelope.of(EventType.USER_REGISTERED, EventSource.AUTH, payloadData);
+        EventEnvelope<UserCreatedPayload> original =
+                EventEnvelope.of(EventType.USER_REGISTERED, EventSource.AUTH, payloadData);
 
         byte[] bytes = serializer.serialize("test-topic", original);
         EventEnvelope<?> deserialized = deserializer.deserialize("test-topic", bytes);

--- a/lib/components/src/test/java/com/marzuk/components/kafka/EventEnvelopeTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/kafka/EventEnvelopeTest.java
@@ -1,13 +1,12 @@
 package com.marzuk.components.kafka;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.marzuk.components.pojos.enums.EventSource;
 import com.marzuk.components.pojos.enums.EventType;
-import org.junit.jupiter.api.Test;
-
 import java.time.Instant;
 import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class EventEnvelopeTest {
 
@@ -28,8 +27,10 @@ class EventEnvelopeTest {
 
     @Test
     void of_generatesUniqueEventIds() {
-        EventEnvelope<String> first = EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
-        EventEnvelope<String> second = EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
+        EventEnvelope<String> first =
+                EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
+        EventEnvelope<String> second =
+                EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
 
         assertThat(first.getEventId()).isNotEqualTo(second.getEventId());
     }
@@ -37,7 +38,8 @@ class EventEnvelopeTest {
     @Test
     void of_timestampIsCloseToNow() {
         Instant before = Instant.now();
-        EventEnvelope<String> envelope = EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
+        EventEnvelope<String> envelope =
+                EventEnvelope.of(EventType.MESSAGE_SENT, EventSource.CHAT, "payload");
         Instant after = Instant.now();
 
         assertThat(envelope.getTimestamp()).isBetween(before, after);
@@ -48,13 +50,14 @@ class EventEnvelopeTest {
         UUID fixedId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         Instant fixedTime = Instant.parse("2024-01-01T00:00:00Z");
 
-        EventEnvelope<Integer> envelope = EventEnvelope.<Integer>builder()
-                .eventId(fixedId)
-                .eventType(EventType.ADMIN_BROADCAST)
-                .timestamp(fixedTime)
-                .source(EventSource.USER)
-                .payload(42)
-                .build();
+        EventEnvelope<Integer> envelope =
+                EventEnvelope.<Integer>builder()
+                        .eventId(fixedId)
+                        .eventType(EventType.ADMIN_BROADCAST)
+                        .timestamp(fixedTime)
+                        .source(EventSource.USER)
+                        .payload(42)
+                        .build();
 
         assertThat(envelope.getEventId()).isEqualTo(fixedId);
         assertThat(envelope.getTimestamp()).isEqualTo(fixedTime);

--- a/lib/components/src/test/java/com/marzuk/components/pojos/dto/user/UserSummaryDTOTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/dto/user/UserSummaryDTOTest.java
@@ -1,11 +1,10 @@
 package com.marzuk.components.pojos.dto.user;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
 
 class UserSummaryDTOTest {
 
@@ -14,12 +13,13 @@ class UserSummaryDTOTest {
     @Test
     void serializationRoundTripPreservesAllFields() throws Exception {
         UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        UserSummaryDTO original = UserSummaryDTO.builder()
-                .id(id)
-                .username("jdoe")
-                .displayName("John Doe")
-                .avatarUrl("https://example.com/avatar.png")
-                .build();
+        UserSummaryDTO original =
+                UserSummaryDTO.builder()
+                        .id(id)
+                        .username("jdoe")
+                        .displayName("John Doe")
+                        .avatarUrl("https://example.com/avatar.png")
+                        .build();
 
         String json = objectMapper.writeValueAsString(original);
         UserSummaryDTO deserialized = objectMapper.readValue(json, UserSummaryDTO.class);
@@ -29,12 +29,13 @@ class UserSummaryDTOTest {
 
     @Test
     void nullOptionalFieldsSerializeWithoutError() throws Exception {
-        UserSummaryDTO dto = UserSummaryDTO.builder()
-                .id(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-                .username("jdoe")
-                .displayName(null)
-                .avatarUrl(null)
-                .build();
+        UserSummaryDTO dto =
+                UserSummaryDTO.builder()
+                        .id(UUID.fromString("00000000-0000-0000-0000-000000000002"))
+                        .username("jdoe")
+                        .displayName(null)
+                        .avatarUrl(null)
+                        .build();
 
         String json = objectMapper.writeValueAsString(dto);
         UserSummaryDTO deserialized = objectMapper.readValue(json, UserSummaryDTO.class);

--- a/lib/components/src/test/java/com/marzuk/components/pojos/entity/BaseEntityTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/entity/BaseEntityTest.java
@@ -1,5 +1,7 @@
 package com.marzuk.components.pojos.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import org.junit.jupiter.api.Test;
@@ -8,14 +10,11 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataJpaTest
 @EntityScan(basePackageClasses = BaseEntityTest.class)
 class BaseEntityTest {
 
-    @Autowired
-    private TestEntityManager entityManager;
+    @Autowired private TestEntityManager entityManager;
 
     @Test
     void idAndTimestampsArePopulatedOnPersist() {
@@ -53,7 +52,12 @@ class BaseEntityTest {
     static class SampleEntity extends BaseEntity {
         private String title;
 
-        public String getTitle() { return title; }
-        public void setTitle(String title) { this.title = title; }
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
     }
 }

--- a/lib/components/src/test/java/com/marzuk/components/pojos/response/PageResponseTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/response/PageResponseTest.java
@@ -1,13 +1,12 @@
 package com.marzuk.components.pojos.response;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class PageResponseTest {
 

--- a/lib/components/src/test/java/com/marzuk/components/pojos/response/ResponseTest.java
+++ b/lib/components/src/test/java/com/marzuk/components/pojos/response/ResponseTest.java
@@ -1,10 +1,9 @@
 package com.marzuk.components.pojos.response;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class ResponseTest {
 

--- a/packages/admin-portal/src/main/java/com/marzuk/adminportal/AdminPortalApp.java
+++ b/packages/admin-portal/src/main/java/com/marzuk/adminportal/AdminPortalApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.adminportal", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class AdminPortalApp {
 
     public static void main(String[] args) {

--- a/packages/admin-portal/src/test/java/com/marzuk/adminportal/AdminPortalAppIntegrationTest.java
+++ b/packages/admin-portal/src/test/java/com/marzuk/adminportal/AdminPortalAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.adminportal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -9,21 +15,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AdminPortalAppIntegrationTest {
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -31,9 +28,11 @@ class AdminPortalAppIntegrationTest {
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
     }
 
@@ -44,8 +43,9 @@ class AdminPortalAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/packages/api-gateway/src/main/java/com/marzuk/gateway/GatewayApp.java
+++ b/packages/api-gateway/src/main/java/com/marzuk/gateway/GatewayApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.gateway", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class GatewayApp {
 
     public static void main(String[] args) {

--- a/packages/auth/src/main/java/com/marzuk/auth/AuthApp.java
+++ b/packages/auth/src/main/java/com/marzuk/auth/AuthApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.auth", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class AuthApp {
 
     public static void main(String[] args) {

--- a/packages/auth/src/test/java/com/marzuk/auth/AuthAppIntegrationTest.java
+++ b/packages/auth/src/test/java/com/marzuk/auth/AuthAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,28 +18,20 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AuthAppIntegrationTest {
 
     @Container
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("auth_db")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("auth_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -46,9 +44,11 @@ class AuthAppIntegrationTest {
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
     }
 
@@ -59,8 +59,9 @@ class AuthAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/packages/chat/src/main/java/com/marzuk/chat/ChatApp.java
+++ b/packages/chat/src/main/java/com/marzuk/chat/ChatApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.chat", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class ChatApp {
 
     public static void main(String[] args) {

--- a/packages/chat/src/test/java/com/marzuk/chat/ChatAppIntegrationTest.java
+++ b/packages/chat/src/test/java/com/marzuk/chat/ChatAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.chat;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,28 +18,20 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ChatAppIntegrationTest {
 
     @Container
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("chat_db")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("chat_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -41,17 +39,21 @@ class ChatAppIntegrationTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
-        registry.add("spring.autoconfigure.exclude", () ->
-                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration");
+        registry.add(
+                "spring.autoconfigure.exclude",
+                () ->
+                        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                                + "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration");
 
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
     }
 
@@ -62,8 +64,9 @@ class ChatAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/packages/notification/src/main/java/com/marzuk/notification/NotificationApp.java
+++ b/packages/notification/src/main/java/com/marzuk/notification/NotificationApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.notification", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class NotificationApp {
 
     public static void main(String[] args) {

--- a/packages/notification/src/test/java/com/marzuk/notification/NotificationAppIntegrationTest.java
+++ b/packages/notification/src/test/java/com/marzuk/notification/NotificationAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.notification;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,28 +18,20 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class NotificationAppIntegrationTest {
 
     @Container
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("notification_db")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("notification_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -41,18 +39,22 @@ class NotificationAppIntegrationTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
-        registry.add("spring.autoconfigure.exclude", () ->
-                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration");
+        registry.add(
+                "spring.autoconfigure.exclude",
+                () ->
+                        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                                + "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration,"
+                                + "org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration");
 
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
     }
 
@@ -63,8 +65,9 @@ class NotificationAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/packages/storage/src/main/java/com/marzuk/storage/StorageApp.java
+++ b/packages/storage/src/main/java/com/marzuk/storage/StorageApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.storage", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class StorageApp {
 
     public static void main(String[] args) {

--- a/packages/storage/src/main/java/com/marzuk/storage/config/MinioConfig.java
+++ b/packages/storage/src/main/java/com/marzuk/storage/config/MinioConfig.java
@@ -19,9 +19,6 @@ public class MinioConfig {
 
     @Bean
     public MinioClient minioClient() {
-        return MinioClient.builder()
-                .endpoint(endpoint)
-                .credentials(accessKey, secretKey)
-                .build();
+        return MinioClient.builder().endpoint(endpoint).credentials(accessKey, secretKey).build();
     }
 }

--- a/packages/storage/src/test/java/com/marzuk/storage/StorageAppIntegrationTest.java
+++ b/packages/storage/src/test/java/com/marzuk/storage/StorageAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.storage;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,28 +18,20 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class StorageAppIntegrationTest {
 
     @Container
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("file_db")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("file_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -46,9 +44,11 @@ class StorageAppIntegrationTest {
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
 
         registry.add("minio.endpoint", () -> "http://localhost:9000");
@@ -63,8 +63,9 @@ class StorageAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/packages/user/src/main/java/com/marzuk/user/UserApp.java
+++ b/packages/user/src/main/java/com/marzuk/user/UserApp.java
@@ -8,8 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServic
 @Slf4j
 @SpringBootApplication(
         scanBasePackages = {"com.marzuk.user", "com.marzuk.components"},
-        exclude = {UserDetailsServiceAutoConfiguration.class}
-)
+        exclude = {UserDetailsServiceAutoConfiguration.class})
 public class UserApp {
 
     public static void main(String[] args) {

--- a/packages/user/src/test/java/com/marzuk/user/UserAppIntegrationTest.java
+++ b/packages/user/src/test/java/com/marzuk/user/UserAppIntegrationTest.java
@@ -1,5 +1,11 @@
 package com.marzuk.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,28 +18,20 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.Base64;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class UserAppIntegrationTest {
 
     @Container
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("user_db")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("user_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    TestRestTemplate restTemplate;
+    @Autowired TestRestTemplate restTemplate;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
@@ -41,17 +39,21 @@ class UserAppIntegrationTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
-        registry.add("spring.autoconfigure.exclude", () ->
-                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration," +
-                "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration");
+        registry.add(
+                "spring.autoconfigure.exclude",
+                () ->
+                        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+                                + "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration");
 
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
 
-        registry.add("jwt.public-key",
+        registry.add(
+                "jwt.public-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-        registry.add("jwt.private-key",
+        registry.add(
+                "jwt.private-key",
                 () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
     }
 
@@ -62,8 +64,9 @@ class UserAppIntegrationTest {
 
     @Test
     void actuatorHealth_returnsUp_confirmingDatasourceConnected() {
-        ResponseEntity<Map> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/actuator/health", Map.class);
+        ResponseEntity<Map> response =
+                restTemplate.getForEntity(
+                        "http://localhost:" + port + "/actuator/health", Map.class);
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).containsEntry("status", "UP");

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,28 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.43.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <java>
+                        <includes>
+                            <include>lib/**/src/main/java/**/*.java</include>
+                            <include>lib/**/src/test/java/**/*.java</include>
+                            <include>packages/**/src/main/java/**/*.java</include>
+                            <include>packages/**/src/test/java/**/*.java</include>
+                        </includes>
+                        <googleJavaFormat>
+                            <version>1.22.0</version>
+                            <style>AOSP</style>
+                        </googleJavaFormat>
+                        <removeUnusedImports/>
+                    </java>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>


### PR DESCRIPTION
## Related Issue
Closes: #33

## What I Did
- Add Spotless Maven plugin (Google Java Format 1.22.0) to root `pom.xml` for consistent code formatting
- Add `infrastructure/bash/git_hooks/pre-commit` hook that runs `mvn spotless:check` before each commit
- Add `infrastructure/bash/push_images/push_release.sh` to build JARs, tag from latest git tag, and push Docker images
- Add `infrastructure/bash/push_images/push_snapshot.sh` to build JARs, tag with commit SHA, and push Docker images
- Add `infrastructure/bash/monitor.sh` to poll `/actuator/health/liveness` on all local services and print UP/DOWN status
- Update `.gitignore` to exclude `.secrets/` directory

See implementation plan: [docs/plan/task_plan_33.md](docs/plan/task_plan_33.md)

## How to Test
- Run `mvn spotless:check` — should pass on clean checkout
- Run `mvn spotless:apply` after introducing a formatting violation — should auto-fix
- Run `./infrastructure/bash/monitor.sh` — should show `[DOWN]` for all services when none are running
- Copy `infrastructure/bash/git_hooks/pre-commit` to `.git/hooks/pre-commit` and attempt a commit with mis-formatted Java — commit should be blocked

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes