### PR TITLE
Create Credential entity and repository (#40)

### DIFF
--- a/docs/plan/task_plan_40.md
+++ b/docs/plan/task_plan_40.md
@@ -1,0 +1,112 @@
+# Task Plan — Issue #40: Create Credential Entity and Repository
+
+## What
+
+Create the `Credential` JPA entity and `CredentialRepository` in the `auth` service. This is the persistence foundation for authentication — registration, login, account locking, and email verification all depend on it.
+
+## Services and Layers Involved
+
+- **`lib/components`** — new `Role` enum (shared across services)
+- **`packages/auth`** — entity, repository, Liquibase migration, dependency addition
+
+## Reusable Components
+
+- `Role` enum placed in `lib/components` under `com.marzuk.components.pojos.enums.auth` so other services (e.g. `user`, `api-gateway`) can reference it without depending on `auth`.
+
+## Package Structure
+
+```
+lib/components/.../pojos/enums/auth/
+└── Role.java
+
+packages/auth/.../
+├── entities/
+│   └── Credential.java
+└── features/
+    └── credentials/
+        └── CredentialRepository.java
+```
+
+## Implementation Steps
+
+### 1. Role Enum — `lib/components`
+
+**File:** `lib/components/src/main/java/com/marzuk/components/pojos/enums/auth/Role.java`
+
+```java
+public enum Role { USER, ADMIN }
+```
+
+### 2. Add Liquibase to `packages/auth/pom.xml`
+
+```xml
+<dependency>
+    <groupId>org.liquibase</groupId>
+    <artifactId>liquibase-core</artifactId>
+</dependency>
+```
+
+### 3. Liquibase Changelog
+
+```
+packages/auth/src/main/resources/db/changelog/
+├── db.changelog-master.yaml
+└── changes/
+    └── 001-create-credentials-table.yaml
+```
+
+Creates the `credentials` table with all columns and the unique constraint on `email`.  
+`application.yml` — `ddl-auto: validate`, add `spring.liquibase.change-log`.
+
+### 4. Credential Entity
+
+**File:** `packages/auth/src/main/java/com/marzuk/auth/entities/Credential.java`
+
+Extends `BaseEntity`. Uses Lombok (`@Getter`, `@Setter`, `@NoArgsConstructor`, `@Builder`, `@AllArgsConstructor`).
+
+| Field           | Type      | Column                          |
+|-----------------|-----------|---------------------------------|
+| `email`         | `String`  | `unique, not null`              |
+| `passwordHash`  | `String`  | `not null`                      |
+| `role`          | `Role`    | `@Enumerated(STRING)`, `not null` |
+| `locked`        | `boolean` | `not null`                      |
+| `emailVerified` | `boolean` | `not null`                      |
+| `failedAttempts`| `int`     | `not null`                      |
+| `lockedUntil`   | `Instant` | nullable                        |
+
+### 5. CredentialRepository
+
+**File:** `packages/auth/src/main/java/com/marzuk/auth/features/credentials/CredentialRepository.java`
+
+```java
+public interface CredentialRepository extends JpaRepository<Credential, UUID> {
+    Optional<Credential> findByEmail(String email);
+}
+```
+
+## Tests
+
+### Unit — `CredentialTest.java`
+
+- Builder defaults: `locked=false`, `failedAttempts=0`, `role=USER`, `emailVerified=false`
+
+### Integration — `CredentialRepositoryIntegrationTest.java` (Testcontainers + PostgreSQL)
+
+- Liquibase runs automatically against the container
+- Save and retrieve by email (`findByEmail`)
+- `findByEmail` returns `Optional.empty()` for unknown email
+- Duplicate email throws `DataIntegrityViolationException`
+
+## Files to Create/Modify
+
+| Action     | File |
+|------------|------|
+| **Create** | `lib/components/.../pojos/enums/auth/Role.java` |
+| **Modify** | `packages/auth/pom.xml` — add `liquibase-core` |
+| **Create** | `packages/auth/.../resources/db/changelog/db.changelog-master.yaml` |
+| **Create** | `packages/auth/.../resources/db/changelog/changes/001-create-credentials-table.yaml` |
+| **Modify** | `packages/auth/.../resources/application.yml` |
+| **Create** | `packages/auth/.../entities/Credential.java` |
+| **Create** | `packages/auth/.../features/credentials/CredentialRepository.java` |
+| **Create** | `packages/auth/.../test/.../entities/CredentialTest.java` |
+| **Create** | `packages/auth/.../test/.../features/credentials/CredentialRepositoryIntegrationTest.java` |

--- a/lib/components/src/main/java/com/marzuk/components/pojos/enums/auth/Role.java
+++ b/lib/components/src/main/java/com/marzuk/components/pojos/enums/auth/Role.java
@@ -1,0 +1,6 @@
+package com.marzuk.components.pojos.enums.auth;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/packages/auth/pom.xml
+++ b/packages/auth/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/packages/auth/src/main/java/com/marzuk/auth/entities/Credential.java
+++ b/packages/auth/src/main/java/com/marzuk/auth/entities/Credential.java
@@ -1,0 +1,46 @@
+package com.marzuk.auth.entities;
+
+import com.marzuk.components.pojos.entity.BaseEntity;
+import com.marzuk.components.pojos.enums.auth.Role;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "credentials")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Credential extends BaseEntity {
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(nullable = false)
+    private boolean locked;
+
+    @Column(nullable = false)
+    private boolean emailVerified;
+
+    @Column(nullable = false)
+    private int failedAttempts;
+
+    private Instant lockedUntil;
+}

--- a/packages/auth/src/main/java/com/marzuk/auth/features/credentials/CredentialRepository.java
+++ b/packages/auth/src/main/java/com/marzuk/auth/features/credentials/CredentialRepository.java
@@ -1,0 +1,11 @@
+package com.marzuk.auth.features.credentials;
+
+import com.marzuk.auth.entities.Credential;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CredentialRepository extends JpaRepository<Credential, UUID> {
+
+    Optional<Credential> findByEmail(String email);
+}

--- a/packages/auth/src/main/java/com/marzuk/auth/features/credentials/CredentialRepository.java
+++ b/packages/auth/src/main/java/com/marzuk/auth/features/credentials/CredentialRepository.java
@@ -4,7 +4,9 @@ import com.marzuk.auth.entities.Credential;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CredentialRepository extends JpaRepository<Credential, UUID> {
 
     Optional<Credential> findByEmail(String email);

--- a/packages/auth/src/main/resources/application.yml
+++ b/packages/auth/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
     hibernate:
       ddl-auto: ${JPA_DDL_AUTO:validate}
     open-in-view: false
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml
 
 server:
   port: 8080

--- a/packages/auth/src/main/resources/db/changelog/changes/001-create-credentials-table.yaml
+++ b/packages/auth/src/main/resources/db/changelog/changes/001-create-credentials-table.yaml
@@ -1,0 +1,72 @@
+databaseChangeLog:
+  - changeSet:
+      id: 001-create-credentials-table
+      author: marzuk
+      changes:
+        - createTable:
+            tableName: credentials
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_credentials_email
+              - column:
+                  name: password_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: varchar(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email_verified
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: failed_attempts
+                  type: integer
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_until
+                  type: timestamp with time zone

--- a/packages/auth/src/main/resources/db/changelog/changes/001-create-credentials-table.yaml
+++ b/packages/auth/src/main/resources/db/changelog/changes/001-create-credentials-table.yaml
@@ -38,7 +38,7 @@ databaseChangeLog:
                   constraints:
                     nullable: false
                     unique: true
-                    uniqueConstraintName: uq_credentials_email
+                    uniqueConstraintName: credentials_email_uq
               - column:
                   name: password_hash
                   type: varchar(255)

--- a/packages/auth/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/packages/auth/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - includeAll:
+      path: db/changelog/changes/
+      relativeToChangelogFile: false

--- a/packages/auth/src/test/java/com/marzuk/auth/entities/CredentialTest.java
+++ b/packages/auth/src/test/java/com/marzuk/auth/entities/CredentialTest.java
@@ -1,0 +1,53 @@
+package com.marzuk.auth.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marzuk.components.pojos.enums.auth.Role;
+import org.junit.jupiter.api.Test;
+
+class CredentialTest {
+
+    @Test
+    void builder_defaults_lockedIsFalse() {
+        Credential credential = Credential.builder()
+                .email("user@example.com")
+                .passwordHash("hash")
+                .role(Role.USER)
+                .build();
+
+        assertThat(credential.isLocked()).isFalse();
+    }
+
+    @Test
+    void builder_defaults_failedAttemptsIsZero() {
+        Credential credential = Credential.builder()
+                .email("user@example.com")
+                .passwordHash("hash")
+                .role(Role.USER)
+                .build();
+
+        assertThat(credential.getFailedAttempts()).isZero();
+    }
+
+    @Test
+    void builder_defaults_emailVerifiedIsFalse() {
+        Credential credential = Credential.builder()
+                .email("user@example.com")
+                .passwordHash("hash")
+                .role(Role.USER)
+                .build();
+
+        assertThat(credential.isEmailVerified()).isFalse();
+    }
+
+    @Test
+    void builder_setsRole_user() {
+        Credential credential = Credential.builder()
+                .email("user@example.com")
+                .passwordHash("hash")
+                .role(Role.USER)
+                .build();
+
+        assertThat(credential.getRole()).isEqualTo(Role.USER);
+    }
+}

--- a/packages/auth/src/test/java/com/marzuk/auth/features/credentials/CredentialRepositoryIntegrationTest.java
+++ b/packages/auth/src/test/java/com/marzuk/auth/features/credentials/CredentialRepositoryIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.marzuk.auth.features.credentials;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marzuk.auth.entities.Credential;
+import com.marzuk.components.pojos.enums.auth.Role;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+class CredentialRepositoryIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("auth_db")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
+
+    @Autowired
+    private CredentialRepository credentialRepository;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) throws Exception {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        registry.add(
+                "jwt.public-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        registry.add(
+                "jwt.private-key",
+                () -> Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
+    }
+
+    private Credential buildCredential(String email) {
+        Credential credential = Credential.builder()
+                .email(email)
+                .passwordHash("hashed-password")
+                .role(Role.USER)
+                .build();
+        credential.setCreatedBy("system");
+        credential.setUpdatedBy("system");
+        return credential;
+    }
+
+    @Test
+    void findByEmail_returnsCredential_whenEmailExists() {
+        credentialRepository.save(buildCredential("alice@example.com"));
+
+        Optional<Credential> result = credentialRepository.findByEmail("alice@example.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo("alice@example.com");
+    }
+
+    @Test
+    void findByEmail_returnsEmpty_whenEmailNotFound() {
+        Optional<Credential> result = credentialRepository.findByEmail("nobody@example.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void save_throwsDataIntegrityViolationException_onDuplicateEmail() {
+        credentialRepository.save(buildCredential("duplicate@example.com"));
+
+        assertThatThrownBy(() -> credentialRepository.saveAndFlush(buildCredential("duplicate@example.com")))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes: #40

## What I Did
- Add `Role` enum to `lib/components` under `com.marzuk.components.pojos.enums.auth`
- Add `Credential` entity extending `BaseEntity` in `packages/auth/entities`
- Add `CredentialRepository` with `findByEmail` in `packages/auth/features/credentials`
- Add Liquibase migration (`001-create-credentials-table`) to create the `credentials` table
- Add unit and integration tests (Testcontainers + PostgreSQL)

## How to Test
- Run `mvn test -pl packages/auth` — integration test spins up a Postgres container via Testcontainers and verifies entity persistence, `findByEmail`, and unique constraint enforcement

## Implementation Plan
See [docs/plan/task_plan_40.md](docs/plan/task_plan_40.md)

## Checklist
- [ ] Code works
- [ ] Tested locally
- [ ] No breaking changes